### PR TITLE
Filter keys from response

### DIFF
--- a/apps/admin/src/components/form/FormEdit/FormEdit.tsx
+++ b/apps/admin/src/components/form/FormEdit/FormEdit.tsx
@@ -1,15 +1,23 @@
+import type { ComponentSchema } from 'formiojs'
 import { Edit } from 'react-admin'
 
 import type { FormioSchema } from '../../../types/formio'
 import { CreateEditForm } from '../CreateEditForm'
 
-export const FormEdit = () => (
-  <Edit
-    transform={(data: FormioSchema) => ({
-      ...data,
-      components: data.components,
-    })}
-  >
-    <CreateEditForm isEditForm />
-  </Edit>
-)
+// Keys 'question' and 'position' are provided by the API, but you can't pass them back.
+// For that reason, they are filtered here.
+const replacer = (key: string, val: any) => (key === 'question' || key === 'position' ? undefined : val)
+const filterKeys = (obj: ComponentSchema[]) => JSON.parse(JSON.stringify(obj, replacer))
+
+export const FormEdit = () => {
+  const transform = (data: FormioSchema) => ({
+    ...data,
+    components: filterKeys(data.components),
+  })
+
+  return (
+    <Edit transform={transform}>
+      <CreateEditForm isEditForm />
+    </Edit>
+  )
+}


### PR DESCRIPTION
This filters the keys 'position' and 'question' from the /form PUT request. These keys are created by the backend, but you can't pass them back
