### PR TITLE
Only inputs should have labels

### DIFF
--- a/libs/formio/src/template/label/label.tsx
+++ b/libs/formio/src/template/label/label.tsx
@@ -1,11 +1,11 @@
-export const label = (ctx: any) =>
-  ctx.component.label &&
-  `
-  <label
-    ref="label"
-    class="${ctx.label.className} ams-label"
-    for="${ctx.instance.id}-${ctx.component.key}"
-  >
-    ${ctx.t(ctx.component.label, { _userInput: true })}
-  </label>
+const labelMarkup = (ctx: any) => `
+<label
+  ref="label"
+  class="ams-label"
+  for="${ctx.instance.id}-${ctx.component.key}"
+>
+  ${ctx.t(ctx.component.label, { _userInput: true })}
+</label>
 `
+
+export const label = (ctx: any) => (ctx.component.input ? labelMarkup(ctx) : '')


### PR DESCRIPTION
Formio also renders a label for buttons, which isn't necessary. Only inputs should have labels.
