### PR TITLE
Get Contact page question labels and descriptions from back-end

### DIFF
--- a/apps/public/src/app/(general)/Home.tsx
+++ b/apps/public/src/app/(general)/Home.tsx
@@ -1,14 +1,15 @@
 'use client'
 
 import { Paragraph } from '@amsterdam/design-system-react'
-import type { StaticFormPanelComponentOutput, StaticFormTextFieldInputComponentOutput } from '@meldingen/api-client'
 import { FormRenderer } from '@meldingen/form-renderer'
 import { Grid } from '@meldingen/ui'
 import { useActionState } from 'react'
 
+import type { StaticFormTextAreaComponentOutput } from 'apps/public/src/apiClientProxy'
+
 import { postPrimaryForm } from './actions'
 
-type Component = StaticFormPanelComponentOutput | StaticFormTextFieldInputComponentOutput
+type Component = StaticFormTextAreaComponentOutput
 
 const initialState: { message?: string } = {}
 

--- a/apps/public/src/app/(general)/aanvullende-vragen/[classification]/[panelId]/page.tsx
+++ b/apps/public/src/app/(general)/aanvullende-vragen/[classification]/[panelId]/page.tsx
@@ -1,4 +1,4 @@
-import type { FormPanelComponentOutput } from '@meldingen/api-client'
+import type { FormPanelComponentOutput } from 'apps/public/src/apiClientProxy'
 import type { Metadata } from 'next'
 
 import { getFormClassificationByClassificationId } from 'apps/public/src/apiClientProxy'

--- a/apps/public/src/app/(general)/bijlage/Bijlage.tsx
+++ b/apps/public/src/app/(general)/bijlage/Bijlage.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Column, Field, Heading, Label, Paragraph, UnorderedList } from '@amsterdam/design-system-react'
-import type { AttachmentOutput } from '@meldingen/api-client'
+import type { AttachmentOutput } from 'apps/public/src/apiClientProxy'
 import { Grid, SubmitButton } from '@meldingen/ui'
 import { useState } from 'react'
 import type { ChangeEvent } from 'react'

--- a/apps/public/src/app/(general)/bijlage/_components/FileUpload.tsx
+++ b/apps/public/src/app/(general)/bijlage/_components/FileUpload.tsx
@@ -1,4 +1,4 @@
-import type { AttachmentOutput } from '@meldingen/api-client'
+import type { AttachmentOutput } from 'apps/public/src/apiClientProxy'
 import type { InputHTMLAttributes, ChangeEvent } from 'react'
 
 import styles from './FileUpload.module.css'

--- a/apps/public/src/app/(general)/contact/Contact.tsx
+++ b/apps/public/src/app/(general)/contact/Contact.tsx
@@ -4,13 +4,17 @@ import { Alert, Heading, Label, Paragraph, TextInput } from '@amsterdam/design-s
 import { Grid, SubmitButton } from '@meldingen/ui'
 import { useActionState } from 'react'
 
+import type { StaticFormTextAreaComponentOutput } from 'apps/public/src/apiClientProxy'
+
 import { BackLink } from '../_components/BackLink'
 
 import { postContactForm } from './actions'
 
+type Component = StaticFormTextAreaComponentOutput
+
 const initialState: { message?: string } = {}
 
-export const Contact = () => {
+export const Contact = ({ formData }: { formData: Component[] }) => {
   const [formState, formAction] = useActionState(postContactForm, initialState)
 
   return (
@@ -39,9 +43,15 @@ export const Contact = () => {
             </Alert>
           )}
           <Label htmlFor="email-input" optional className="ams-mb--sm">
-            Wat is uw e-mailadres?
+            {formData[0].label}
           </Label>
+          {formData[0].description && (
+            <Paragraph size="small" id="email-input-description">
+              {formData[0].description}
+            </Paragraph>
+          )}
           <TextInput
+            aria-describedby={formData[0].description ? 'email-input-description' : undefined}
             name="email"
             id="email-input"
             type="email"
@@ -51,9 +61,21 @@ export const Contact = () => {
             className="ams-mb--sm"
           />
           <Label htmlFor="tel-input" optional className="ams-mb--sm">
-            Wat is uw telefoonnummer?
+            {formData[1].label}
           </Label>
-          <TextInput name="phone" id="tel-input" type="tel" autoComplete="tel" className="ams-mb--sm" />
+          {formData[1].description && (
+            <Paragraph size="small" id="tel-input-description">
+              {formData[1].description}
+            </Paragraph>
+          )}
+          <TextInput
+            aria-describedby={formData[1].description ? 'tel-input-description' : undefined}
+            autoComplete="tel"
+            className="ams-mb--sm"
+            id="tel-input"
+            name="phone"
+            type="tel"
+          />
           <SubmitButton>Volgende vraag</SubmitButton>
         </form>
       </Grid.Cell>

--- a/apps/public/src/app/(general)/contact/actions.test.ts
+++ b/apps/public/src/app/(general)/contact/actions.test.ts
@@ -1,11 +1,11 @@
-import { postMeldingByMeldingIdContact } from '@meldingen/api-client'
+import { postMeldingByMeldingIdContact } from 'apps/public/src/apiClientProxy'
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 import type { Mock } from 'vitest'
 
 import { postContactForm } from './actions'
 
-vi.mock('@meldingen/api-client', () => ({
+vi.mock('apps/public/src/apiClientProxy', () => ({
   postMeldingByMeldingIdContact: vi.fn(),
 }))
 

--- a/apps/public/src/app/(general)/contact/page.tsx
+++ b/apps/public/src/app/(general)/contact/page.tsx
@@ -1,9 +1,24 @@
 import type { Metadata } from 'next'
 
+import type { StaticFormTextAreaComponentOutput } from 'apps/public/src/apiClientProxy'
+import { getStaticForm, getStaticFormByStaticFormId } from 'apps/public/src/apiClientProxy'
+
 import { Contact } from './Contact'
 
 export const metadata: Metadata = {
   title: 'Stap 3 van 4 - Gegevens - Gemeente Amsterdam',
 }
 
-export default async () => <Contact />
+export default async () => {
+  const contactFormId = await getStaticForm().then((response) => response.find((form) => form.type === 'contact')?.id)
+
+  if (!contactFormId) return undefined
+
+  const contactForm = (await getStaticFormByStaticFormId({ staticFormId: contactFormId }))?.components
+
+  const textareaComponents =
+    contactForm?.filter((component): component is StaticFormTextAreaComponentOutput => component.type === 'textarea') ||
+    []
+
+  return <Contact formData={textareaComponents} />
+}

--- a/apps/public/src/app/(general)/locatie/actions.test.tsx
+++ b/apps/public/src/app/(general)/locatie/actions.test.tsx
@@ -1,4 +1,4 @@
-import { postMeldingByMeldingIdLocation } from '@meldingen/api-client'
+import { postMeldingByMeldingIdLocation } from 'apps/public/src/apiClientProxy'
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 import type { Mock } from 'vitest'
@@ -13,7 +13,7 @@ vi.mock('next/navigation', () => ({
   redirect: vi.fn(),
 }))
 
-vi.mock('@meldingen/api-client', () => ({
+vi.mock('apps/public/src/apiClientProxy', () => ({
   postMeldingByMeldingIdLocation: vi.fn(),
 }))
 

--- a/apps/public/src/app/(general)/page.tsx
+++ b/apps/public/src/app/(general)/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 
+import type { StaticFormTextAreaComponentOutput } from 'apps/public/src/apiClientProxy'
 import { getStaticForm, getStaticFormByStaticFormId } from 'apps/public/src/apiClientProxy'
 
 import { Home } from './Home'
@@ -19,5 +20,9 @@ export default async () => {
 
   const primaryForm = (await getStaticFormByStaticFormId({ staticFormId: primaryFormId }))?.components
 
-  return <Home formData={primaryForm} />
+  const textareaComponents =
+    primaryForm?.filter((component): component is StaticFormTextAreaComponentOutput => component.type === 'textarea') ||
+    []
+
+  return <Home formData={textareaComponents} />
 }

--- a/apps/public/src/app/(general)/samenvatting/_utils/getSummaryData.ts
+++ b/apps/public/src/app/(general)/samenvatting/_utils/getSummaryData.ts
@@ -1,4 +1,4 @@
-import type { GetMeldingByMeldingIdAnswersResponse, MeldingOutput } from '@meldingen/api-client'
+import type { GetMeldingByMeldingIdAnswersResponse, MeldingOutput } from 'apps/public/src/apiClientProxy'
 
 import type { Coordinates } from 'apps/public/src/types'
 

--- a/libs/form-renderer/src/FormRenderer.tsx
+++ b/libs/form-renderer/src/FormRenderer.tsx
@@ -1,11 +1,11 @@
+import { SubmitButton } from '@meldingen/ui'
 import type {
   FormCheckboxComponentOutput,
   FormRadioComponentOutput,
   FormSelectComponentOutput,
   FormTextAreaComponentOutput,
   FormTextFieldInputComponentOutput,
-} from '@meldingen/api-client'
-import { SubmitButton } from '@meldingen/ui'
+} from 'apps/public/src/apiClientProxy'
 
 import { Checkbox, Radio, Select, TextArea, TextInput } from './components'
 


### PR DESCRIPTION
This also changes all imports from `@meldingen/api-client` to `apps/public/src/apiClientProxy`. Not strictly necessary, but it's probably safer to do that the same way everywhere in `public`.