### PR TITLE
Remove Amsterdam Design System from Dependabot group excludes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,6 @@ updates:
         exclude-patterns:
           - '@hey-api/client-fetch'
           - '@hey-api/openapi-ts'
-          - '@amsterdam/design-system-*'
         update-types:
           - 'patch'
           - 'minor'


### PR DESCRIPTION
Amsterdam Design System released a 1.0.0 version (🎉), so we don't need to exclude those packages anymore. 