### PR TITLE
Use Next Form component everywhere and disable HTML5 validation

### DIFF
--- a/apps/back-office/src/app/melding/[meldingId]/wijzig-status/ChangeState.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/wijzig-status/ChangeState.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Field, Grid, Heading, Label, Paragraph, Select } from '@amsterdam/design-system-react'
+import Form from 'next/form'
 import { useTranslations } from 'next-intl'
 import { useActionState } from 'react'
 
@@ -34,7 +35,7 @@ export const ChangeState = ({ meldingId, meldingState, publicId }: Props) => {
           {t('change-state.title', { publicId })}
         </Heading>
         {errorMessage && <Paragraph>{errorMessage}</Paragraph>}
-        <form action={formAction}>
+        <Form action={formAction} noValidate>
           <Field className="ams-mb-l">
             <Label htmlFor="state">{t('change-state.label')}</Label>
             <Select defaultValue={isValidMeldingState(meldingState) ? meldingState : undefined} id="state" name="state">
@@ -44,7 +45,7 @@ export const ChangeState = ({ meldingId, meldingState, publicId }: Props) => {
             </Select>
           </Field>
           <SubmitButton>{t('change-state.submit-button')}</SubmitButton>
-        </form>
+        </Form>
       </Grid.Cell>
     </Grid>
   )

--- a/apps/melding-form/src/app/(general)/aanvullende-vragen/[classificationId]/[panelId]/AdditionalQuestions.tsx
+++ b/apps/melding-form/src/app/(general)/aanvullende-vragen/[classificationId]/[panelId]/AdditionalQuestions.tsx
@@ -38,9 +38,11 @@ const mapValidationErrors = (errors: ValidationError[]) =>
     label: validationError.message,
   }))
 
-// TODO: fix types
 export type Props = {
-  action: any
+  action: (
+    _: unknown,
+    formData: FormData,
+  ) => Promise<{ errorMessage?: string; formData?: FormData; validationErrors?: ValidationError[] }>
   formComponents: Component[]
   panelLabel: string
   previousPanelPath: string

--- a/apps/melding-form/src/app/(general)/aanvullende-vragen/[classificationId]/[panelId]/actions.ts
+++ b/apps/melding-form/src/app/(general)/aanvullende-vragen/[classificationId]/[panelId]/actions.ts
@@ -78,7 +78,7 @@ export const postForm = async (
   if (resultsWithValidationError.length > 0) {
     return {
       validationErrors: resultsWithValidationError.map((result) => ({
-        key: result?.key,
+        key: result?.key || 'fallback-key',
         message: handleApiError(result?.value.error),
       })),
       formData,

--- a/apps/melding-form/src/app/(general)/bijlage/Attachments.tsx
+++ b/apps/melding-form/src/app/(general)/bijlage/Attachments.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Alert, ErrorMessage, Field, FileList, Label, Paragraph } from '@amsterdam/design-system-react'
+import Form from 'next/form'
 import { useTranslations } from 'next-intl'
 import { useActionState, useRef, useState } from 'react'
 import type { ChangeEvent } from 'react'
@@ -106,7 +107,7 @@ export const Attachments = ({ formData, meldingId, token }: Props) => {
 
       <FormHeader title={t('title')} step={t('step')} />
 
-      <form ref={formRef} action={formAction}>
+      <Form action={formAction} noValidate ref={formRef}>
         <Field invalid={Boolean(errorMessage)} className="ams-mb-m">
           <h1 className={styles.h1}>
             <Label htmlFor="file-upload" optional>
@@ -145,7 +146,7 @@ export const Attachments = ({ formData, meldingId, token }: Props) => {
           )}
         </Field>
         <SubmitButton>{t('submit-button')}</SubmitButton>
-      </form>
+      </Form>
     </>
   )
 }

--- a/apps/melding-form/src/app/(general)/contact/Contact.tsx
+++ b/apps/melding-form/src/app/(general)/contact/Contact.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Alert, Field, Heading, Label, Paragraph, TextInput } from '@amsterdam/design-system-react'
+import Form from 'next/form'
 import { useTranslations } from 'next-intl'
 import { useActionState } from 'react'
 
@@ -39,7 +40,7 @@ export const Contact = ({ formComponents }: { formComponents: StaticFormTextArea
 
       <MarkdownToHtml className="ams-mb-m">{t('description')}</MarkdownToHtml>
 
-      <form action={formAction}>
+      <Form action={formAction} noValidate>
         <Field>
           <Label htmlFor="email-input" optional>
             {emailLabel}
@@ -89,7 +90,7 @@ export const Contact = ({ formComponents }: { formComponents: StaticFormTextArea
         </Field>
 
         <SubmitButton>{t('submit-button')}</SubmitButton>
-      </form>
+      </Form>
     </>
   )
 }

--- a/apps/melding-form/src/app/(general)/locatie/Location.tsx
+++ b/apps/melding-form/src/app/(general)/locatie/Location.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Alert, Heading, Paragraph, StandaloneLink } from '@amsterdam/design-system-react'
+import Form from 'next/form'
 import NextLink from 'next/link'
 import { useTranslations } from 'next-intl'
 import { useActionState } from 'react'
@@ -46,14 +47,14 @@ export const Location = ({ locationData }: Props) => {
         </StandaloneLink>
       </NextLink>
 
-      <form action={formAction}>
+      <Form action={formAction} noValidate>
         <input
           type="hidden"
           name="coordinates"
           value={locationData?.coordinates ? JSON.stringify(locationData?.coordinates) : undefined}
         />
         <SubmitButton>{t('submit-button')}</SubmitButton>
-      </form>
+      </Form>
     </>
   )
 }

--- a/apps/melding-form/src/app/(general)/samenvatting/Summary.tsx
+++ b/apps/melding-form/src/app/(general)/samenvatting/Summary.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Alert, FileList, Heading, Paragraph } from '@amsterdam/design-system-react'
+import Form from 'next/form'
 import { useTranslations } from 'next-intl'
 import { useActionState } from 'react'
 
@@ -103,9 +104,9 @@ export const Summary = ({ attachments, primaryForm, additionalQuestions, locatio
         )}
       </SummaryList>
 
-      <form action={formAction}>
+      <Form action={formAction} noValidate>
         <SubmitButton>{t('submit-button')}</SubmitButton>
-      </form>
+      </Form>
     </>
   )
 }

--- a/apps/melding-form/src/app/(map)/locatie/kies/_components/SideBar/SideBar.tsx
+++ b/apps/melding-form/src/app/(map)/locatie/kies/_components/SideBar/SideBar.tsx
@@ -1,4 +1,5 @@
 import { Heading, Paragraph } from '@amsterdam/design-system-react'
+import Form from 'next/form'
 import { useTranslations } from 'next-intl'
 import { useActionState, useEffect, useState } from 'react'
 
@@ -58,7 +59,7 @@ export const SideBar = ({ coordinates, setCoordinates }: Props) => {
         </Heading>
         <Paragraph size="small">{t('description')}</Paragraph>
       </div>
-      <form action={formAction} id="address">
+      <Form action={formAction} id="address" noValidate>
         <Combobox
           address={address}
           setAddress={setAddress}
@@ -66,7 +67,7 @@ export const SideBar = ({ coordinates, setCoordinates }: Props) => {
           errorMessage={errorMessage}
         />
         <input type="hidden" name="coordinates" defaultValue={address ? JSON.stringify(coordinates) : undefined} />
-      </form>
+      </Form>
     </div>
   )
 }

--- a/libs/form-renderer/package.json
+++ b/libs/form-renderer/package.json
@@ -9,5 +9,8 @@
   },
   "license": "EUPL-1.2",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "next": "15.4.3"
+  }
 }

--- a/libs/form-renderer/src/FormRenderer.tsx
+++ b/libs/form-renderer/src/FormRenderer.tsx
@@ -1,3 +1,5 @@
+import Form from 'next/form'
+
 import { Heading, SubmitButton } from '@meldingen/ui'
 
 import { Checkbox, Radio, Select, TextArea, TextInput } from './components'
@@ -50,15 +52,13 @@ export const FormRenderer = ({ action, formComponents, panelLabel, submitButtonT
           {panelLabel}
         </Heading>
       )}
-      {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-      {/* @ts-ignore */}
-      <form className="ams-gap-m" action={action}>
+      <Form action={action} className="ams-gap-m" noValidate>
         {formComponents.map((component) => {
           const errorMessage = validationErrors?.find((error) => error.key === component.key)?.message
           return getComponent(component, hasOneFormComponent, errorMessage)
         })}
         <SubmitButton>{submitButtonText}</SubmitButton>
-      </form>
+      </Form>
     </>
   )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,7 +236,11 @@ importers:
         specifier: 4.21.7
         version: 4.21.7
 
-  libs/form-renderer: {}
+  libs/form-renderer:
+    dependencies:
+      next:
+        specifier: 15.4.3
+        version: 15.4.3(@babel/core@7.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   libs/markdown-to-html:
     dependencies:


### PR DESCRIPTION
- The [Next Form component](https://nextjs.org/docs/app/api-reference/components/form) extends the native `form`-tag with prefetching and other goodies. 
- HTML5 validation doesn't work very well, see [this recommendation by gov.uk](https://design-system.service.gov.uk/patterns/validation/#turn-off-html5-validation)