### PR TITLE
Bump min node version to 20.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "EUPL-1.2",
   "private": true,
   "engines": {
-    "node": "^20",
+    "node": "^20.19",
     "pnpm": "^9"
   },
   "repository": {


### PR DESCRIPTION
# Meldingen

Ticket: none

Vite 7.0.0 needs some crypto hash that is build into this higher version of Node.