### PR TITLE
Rethrow Next redirect error so API client doesn't swallow it

### DIFF
--- a/apps/back-office/src/apiClientProxy.ts
+++ b/apps/back-office/src/apiClientProxy.ts
@@ -5,6 +5,12 @@ import { client } from '@meldingen/api-client'
 
 import { authOptions } from './app/_authentication/authOptions'
 
+client.interceptors.error.use((error) => {
+  // Re-throw Next.js redirect errors so the client's catch block doesn't swallow them
+  if (error instanceof Error && error.message === 'NEXT_REDIRECT') throw error
+  return error
+})
+
 client.setConfig({
   auth: async () => {
     const session = await getServerSession(authOptions)

--- a/apps/back-office/src/app/_authentication/authOptions.ts
+++ b/apps/back-office/src/app/_authentication/authOptions.ts
@@ -133,8 +133,8 @@ export const authOptions: AuthOptions = {
         return refreshAccessToken(token)
       }
 
-      // We have no refresh token. Throwing an error forces sign in again
-      throw new Error('Token has expired')
+      // We have no valid access token. Return an error so apiClientProxy redirects to sign in
+      return { ...token, error: 'AccessTokenExpired' }
     },
     redirect: async ({ baseUrl, url }) => {
       // Use callback url


### PR DESCRIPTION
# Meldingen

Our API client handles errors better after an update, but this caused an issue with Next redirect. The API client now uses `try...catch` blocks around calls, which means errors are properly returned instead of bubbling up. However, Next redirect relies on these errors bubbling up, so we need to rethrow them. 

Before opening a pull request, please ensure your branch is based on `main` and targets `main`.

- [x] Includes AI-assisted code via GitHub Copilot

Check requirements when they are met (strikethrough when not applicable):

- [x] Acknowledges **[team code standards](https://github.com/Amsterdam/meldingen-frontend/tree/main/docs)**
- [ ] ~~Has **unit tests** with 100% coverage (if feasible) and all test should pass~~
- [x] Has **error handling** and **loading states**
- [ ] ~~Is **responsive and respects WCAG**~~
- [ ] ~~**Documentation** has been updated~~
- [x] **Required PR checks** have passed

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
