### PR TITLE
Move root utility function and `/samenvatting` utilities to `_utils` folders

### DIFF
--- a/apps/melding-form/src/app/(general)/actions.ts
+++ b/apps/melding-form/src/app/(general)/actions.ts
@@ -5,7 +5,7 @@ import { redirect } from 'next/navigation'
 
 import { patchMeldingByMeldingIdMelder, postMelding } from '@meldingen/api-client'
 
-import { resolveClassificationRedirect } from '../utils'
+import { resolveClassificationRedirect } from '../_utils/resolveClassificationRedirect'
 import { hasValidationErrors } from './_utils/validation/hasValidationErrors'
 import { COOKIES } from '~/constants'
 import { handleApiError } from '~/handleApiError'

--- a/apps/melding-form/src/app/(general)/samenvatting/_utils/getAdditionalQuestionsSummary.test.ts
+++ b/apps/melding-form/src/app/(general)/samenvatting/_utils/getAdditionalQuestionsSummary.test.ts
@@ -1,92 +1,14 @@
 import { http, HttpResponse } from 'msw'
 
-import type { MeldingOutput } from '@meldingen/api-client'
-
-import {
-  getAdditionalQuestionsSummary,
-  getAttachmentsSummary,
-  getContactSummary,
-  getLocationSummary,
-  getMeldingData,
-  getPrimaryFormSummary,
-} from './utils'
+import { getAdditionalQuestionsSummary } from './getAdditionalQuestionsSummary'
 import { TOP_ANCHOR_ID } from '~/constants'
-import { additionalQuestions, melding } from '~/mocks/data'
+import { additionalQuestions } from '~/mocks/data'
 import { ENDPOINTS } from '~/mocks/endpoints'
 import { server } from '~/mocks/node'
 
 const mockMeldingId = '88'
 const mockToken = 'test-token'
 const mockClassificationId = 1
-
-describe('getMeldingData', () => {
-  it('should return correct melding summary', async () => {
-    const result = await getMeldingData(mockMeldingId, mockToken)
-
-    expect(result).toEqual(melding)
-  })
-
-  it('should return an error message when error is returned', async () => {
-    server.use(
-      http.get(ENDPOINTS.GET_MELDING_BY_MELDING_ID_MELDER, () => HttpResponse.json('Error message', { status: 500 })),
-    )
-
-    const testFunction = async () => await getMeldingData(mockMeldingId, mockToken)
-
-    await expect(testFunction).rejects.toThrowError('Failed to fetch melding data.')
-  })
-})
-
-describe('getPrimaryFormSummary', () => {
-  it('returns correct primary form summary', async () => {
-    const result = await getPrimaryFormSummary('Er ligt hier veel afval op straat.')
-
-    expect(result).toEqual({
-      data: {
-        description: 'Er ligt hier veel afval op straat.',
-        key: 'primary',
-        term: 'First question',
-      },
-    })
-  })
-
-  it('returns an error message when getStaticForm returns an error', async () => {
-    server.use(http.get(ENDPOINTS.GET_STATIC_FORM, () => HttpResponse.json('Error message', { status: 500 })))
-
-    const testFunction = async () => await getPrimaryFormSummary('')
-
-    await expect(testFunction).rejects.toThrowError('Failed to fetch static forms.')
-  })
-
-  it('returns an error message when primary form id is not found', async () => {
-    server.use(
-      http.get(ENDPOINTS.GET_STATIC_FORM, () =>
-        HttpResponse.json([
-          {
-            id: '123',
-            type: 'not-primary',
-          },
-        ]),
-      ),
-    )
-
-    const testFunction = async () => await getPrimaryFormSummary('')
-
-    await expect(testFunction).rejects.toThrowError('Primary form id not found.')
-  })
-
-  it('returns an error message when getStaticFormByStaticFormId returns an error', async () => {
-    server.use(
-      http.get(ENDPOINTS.GET_STATIC_FORM_BY_STATIC_FORM_ID, () =>
-        HttpResponse.json({ detail: 'Error message' }, { status: 500 }),
-      ),
-    )
-
-    const testFunction = async () => await getPrimaryFormSummary('')
-
-    await expect(testFunction).rejects.toThrowError('Failed to fetch primary form data.')
-  })
-})
 
 describe('getAdditionalQuestionsSummary', () => {
   it('returns correct additional questions summary', async () => {
@@ -413,86 +335,5 @@ describe('getAdditionalQuestionsSummary', () => {
 
     expect(result.staleAnswerIds).toEqual([201, 202])
     expect(result.data).toHaveLength(1)
-  })
-})
-
-describe('getAttachmentSummary', () => {
-  it('returns correct attachment summary', async () => {
-    const result = await getAttachmentsSummary("Foto's", mockMeldingId, mockToken)
-
-    expect(result).toMatchObject({
-      files: [
-        {
-          blob: expect.any(Blob),
-          fileName: 'IMG_0815.jpg',
-        },
-      ],
-      key: 'attachments',
-      term: "Foto's",
-    })
-  })
-
-  it('returns an error message when getMeldingByMeldingIdAttachmentsMelder returns an error', async () => {
-    server.use(
-      http.get(ENDPOINTS.GET_MELDING_BY_MELDING_ID_ATTACHMENTS_MELDER, () =>
-        HttpResponse.json({ detail: 'Error message' }, { status: 500 }),
-      ),
-    )
-
-    const testFunction = async () => await getAttachmentsSummary("Foto's", mockMeldingId, mockToken)
-
-    await expect(testFunction).rejects.toThrowError('Failed to fetch attachments data.')
-  })
-
-  it('returns an error message when getMeldingByMeldingIdAttachmentByAttachmentIdDownload returns an error', async () => {
-    server.use(
-      http.get(ENDPOINTS.GET_MELDING_BY_MELDING_ID_ATTACHMENT_BY_ATTACHMENT_ID_DOWNLOAD, () =>
-        HttpResponse.json({ detail: 'Error message' }, { status: 500 }),
-      ),
-    )
-
-    const testFunction = async () => await getAttachmentsSummary("Foto's", mockMeldingId, mockToken)
-
-    await expect(testFunction).rejects.toThrowError('Failed to fetch attachment download.')
-  })
-})
-
-describe('getLocationSummary', () => {
-  it('returns correct location summary', () => {
-    const result = getLocationSummary((key) => key, melding)
-
-    expect(result).toEqual({
-      description: 'Oudezijds Voorburgwal 300A, 1012GL Amsterdam',
-      key: 'location',
-      term: 'location-label',
-    })
-  })
-
-  it('returns error message when melding does not have an address', () => {
-    const result = getLocationSummary((key) => key, {} as MeldingOutput)
-
-    expect(result).toEqual({
-      description: 'errors.no-location',
-      key: 'location',
-      term: 'location-label',
-    })
-  })
-})
-
-describe('getContactSummary', () => {
-  it('returns correct contact summary', () => {
-    const result = getContactSummary('Wat zijn uw contactgegevens?', 'test@test.com', '+31612345678')
-
-    expect(result).toEqual({
-      description: ['test@test.com', '+31612345678'],
-      key: 'contact',
-      term: 'Wat zijn uw contactgegevens?',
-    })
-  })
-
-  it('returns undefined when contact details are not filled in', () => {
-    const result = getContactSummary('Wat zijn uw contactgegevens?')
-
-    expect(result).toEqual(undefined)
   })
 })

--- a/apps/melding-form/src/app/(general)/samenvatting/_utils/getAdditionalQuestionsSummary.ts
+++ b/apps/melding-form/src/app/(general)/samenvatting/_utils/getAdditionalQuestionsSummary.ts
@@ -1,58 +1,15 @@
 import type {
   FormPanelComponentOutput,
   GetMeldingByMeldingIdAnswersMelderResponses,
-  MeldingOutput,
   ValueLabelObject,
 } from '@meldingen/api-client'
 
-import {
-  getFormClassificationByClassificationId,
-  getMeldingByMeldingIdAnswersMelder,
-  getMeldingByMeldingIdAttachmentByAttachmentIdDownload,
-  getMeldingByMeldingIdAttachmentsMelder,
-  getStaticForm,
-  getStaticFormByStaticFormId,
-} from '@meldingen/api-client'
-import { getMeldingByMeldingIdMelder } from '@meldingen/api-client'
+import { getFormClassificationByClassificationId, getMeldingByMeldingIdAnswersMelder } from '@meldingen/api-client'
 
-import { getFilteredAnswersByKey } from '../_utils/conditions/getFilteredAnswersByKey'
-import { getFullNLAddress } from '../_utils/getFullNLAddress'
-import { isPanelComponentOutput } from '../_utils/typeGuards'
+import { getFilteredAnswersByKey } from '../../_utils/conditions/getFilteredAnswersByKey'
+import { isPanelComponentOutput } from '../../_utils/typeGuards'
 import { TOP_ANCHOR_ID } from '~/constants'
 import { handleApiError } from '~/handleApiError'
-
-export const getMeldingData = async (meldingId: string, token: string) => {
-  const { data, error } = await getMeldingByMeldingIdMelder({
-    path: { melding_id: parseInt(meldingId, 10) },
-    query: { token },
-  })
-
-  if (error) throw new Error('Failed to fetch melding data.')
-
-  return data
-}
-
-export const getPrimaryFormSummary = async (description: string) => {
-  const { data: staticFormsData, error: staticFormsError } = await getStaticForm()
-
-  if (staticFormsError) throw new Error('Failed to fetch static forms.')
-
-  const primaryFormId = staticFormsData.find((form) => form.type === 'primary')?.id
-
-  if (!primaryFormId) throw new Error('Primary form id not found.')
-
-  const { data: primaryFormData, error: primaryFormError } = await getStaticFormByStaticFormId({
-    path: { static_form_id: primaryFormId },
-  })
-
-  if (primaryFormError) throw new Error('Failed to fetch primary form data.')
-
-  const primaryForm = primaryFormData.components[0]
-
-  return {
-    data: { description, key: 'primary', term: primaryForm.label },
-  }
-}
 
 const findPanelIdByQuestionId = (panels: FormPanelComponentOutput[], id: number) => {
   for (const panel of panels) {
@@ -134,54 +91,5 @@ export const getAdditionalQuestionsSummary = async (meldingId: string, token: st
   return {
     data: includedAnswers,
     staleAnswerIds,
-  }
-}
-
-export const getAttachmentsSummary = async (label: string, meldingId: string, token: string) => {
-  const { data, error } = await getMeldingByMeldingIdAttachmentsMelder({
-    path: { melding_id: parseInt(meldingId, 10) },
-    query: { token },
-  })
-
-  if (error) throw new Error('Failed to fetch attachments data.')
-
-  const attachments = await Promise.all(
-    data.map(async ({ id, original_filename }) => {
-      const { data, error } = await getMeldingByMeldingIdAttachmentByAttachmentIdDownload({
-        path: { attachment_id: id, melding_id: parseInt(meldingId, 10) },
-
-        query: { token, type: 'thumbnail' },
-      })
-
-      if (error) throw new Error('Failed to fetch attachment download.')
-
-      // Returning blob instead of File since the File api is not available in Node.js
-      return {
-        blob: data as Blob,
-        fileName: original_filename,
-      }
-    }),
-  )
-
-  return { files: attachments, key: 'attachments', term: label }
-}
-
-export const getLocationSummary = (t: (key: string) => string, meldingData: MeldingOutput) => {
-  const address = getFullNLAddress(meldingData) || t('errors.no-location')
-
-  return {
-    description: address,
-    key: 'location',
-    term: t('location-label'),
-  }
-}
-
-export const getContactSummary = (label: string, email?: string | null, phone?: string | null) => {
-  if (!email && !phone) return undefined
-
-  return {
-    description: [email, phone].filter((item) => item !== undefined && item !== null), // Filter out undefined or null items
-    key: 'contact',
-    term: label,
   }
 }

--- a/apps/melding-form/src/app/(general)/samenvatting/_utils/getAttachmentsSummary.test.ts
+++ b/apps/melding-form/src/app/(general)/samenvatting/_utils/getAttachmentsSummary.test.ts
@@ -7,7 +7,7 @@ import { server } from '~/mocks/node'
 const mockMeldingId = '88'
 const mockToken = 'test-token'
 
-describe('getAttachmentSummary', () => {
+describe('getAttachmentsSummary', () => {
   it('returns correct attachment summary', async () => {
     const result = await getAttachmentsSummary("Foto's", mockMeldingId, mockToken)
 

--- a/apps/melding-form/src/app/(general)/samenvatting/_utils/getAttachmentsSummary.test.ts
+++ b/apps/melding-form/src/app/(general)/samenvatting/_utils/getAttachmentsSummary.test.ts
@@ -1,0 +1,49 @@
+import { http, HttpResponse } from 'msw'
+
+import { getAttachmentsSummary } from './getAttachmentsSummary'
+import { ENDPOINTS } from '~/mocks/endpoints'
+import { server } from '~/mocks/node'
+
+const mockMeldingId = '88'
+const mockToken = 'test-token'
+
+describe('getAttachmentSummary', () => {
+  it('returns correct attachment summary', async () => {
+    const result = await getAttachmentsSummary("Foto's", mockMeldingId, mockToken)
+
+    expect(result).toMatchObject({
+      files: [
+        {
+          blob: expect.any(Blob),
+          fileName: 'IMG_0815.jpg',
+        },
+      ],
+      key: 'attachments',
+      term: "Foto's",
+    })
+  })
+
+  it('returns an error message when getMeldingByMeldingIdAttachmentsMelder returns an error', async () => {
+    server.use(
+      http.get(ENDPOINTS.GET_MELDING_BY_MELDING_ID_ATTACHMENTS_MELDER, () =>
+        HttpResponse.json({ detail: 'Error message' }, { status: 500 }),
+      ),
+    )
+
+    const testFunction = async () => await getAttachmentsSummary("Foto's", mockMeldingId, mockToken)
+
+    await expect(testFunction).rejects.toThrowError('Failed to fetch attachments data.')
+  })
+
+  it('returns an error message when getMeldingByMeldingIdAttachmentByAttachmentIdDownload returns an error', async () => {
+    server.use(
+      http.get(ENDPOINTS.GET_MELDING_BY_MELDING_ID_ATTACHMENT_BY_ATTACHMENT_ID_DOWNLOAD, () =>
+        HttpResponse.json({ detail: 'Error message' }, { status: 500 }),
+      ),
+    )
+
+    const testFunction = async () => await getAttachmentsSummary("Foto's", mockMeldingId, mockToken)
+
+    await expect(testFunction).rejects.toThrowError('Failed to fetch attachment download.')
+  })
+})

--- a/apps/melding-form/src/app/(general)/samenvatting/_utils/getAttachmentsSummary.ts
+++ b/apps/melding-form/src/app/(general)/samenvatting/_utils/getAttachmentsSummary.ts
@@ -1,0 +1,33 @@
+import {
+  getMeldingByMeldingIdAttachmentByAttachmentIdDownload,
+  getMeldingByMeldingIdAttachmentsMelder,
+} from '@meldingen/api-client'
+
+export const getAttachmentsSummary = async (label: string, meldingId: string, token: string) => {
+  const { data, error } = await getMeldingByMeldingIdAttachmentsMelder({
+    path: { melding_id: parseInt(meldingId, 10) },
+    query: { token },
+  })
+
+  if (error) throw new Error('Failed to fetch attachments data.')
+
+  const attachments = await Promise.all(
+    data.map(async ({ id, original_filename }) => {
+      const { data, error } = await getMeldingByMeldingIdAttachmentByAttachmentIdDownload({
+        path: { attachment_id: id, melding_id: parseInt(meldingId, 10) },
+
+        query: { token, type: 'thumbnail' },
+      })
+
+      if (error) throw new Error('Failed to fetch attachment download.')
+
+      // Returning blob instead of File since the File api is not available in Node.js
+      return {
+        blob: data as Blob,
+        fileName: original_filename,
+      }
+    }),
+  )
+
+  return { files: attachments, key: 'attachments', term: label }
+}

--- a/apps/melding-form/src/app/(general)/samenvatting/_utils/getContactSummary.test.ts
+++ b/apps/melding-form/src/app/(general)/samenvatting/_utils/getContactSummary.test.ts
@@ -1,0 +1,19 @@
+import { getContactSummary } from './getContactSummary'
+
+describe('getContactSummary', () => {
+  it('returns correct contact summary', () => {
+    const result = getContactSummary('Wat zijn uw contactgegevens?', 'test@test.com', '+31612345678')
+
+    expect(result).toEqual({
+      description: ['test@test.com', '+31612345678'],
+      key: 'contact',
+      term: 'Wat zijn uw contactgegevens?',
+    })
+  })
+
+  it('returns undefined when contact details are not filled in', () => {
+    const result = getContactSummary('Wat zijn uw contactgegevens?')
+
+    expect(result).toEqual(undefined)
+  })
+})

--- a/apps/melding-form/src/app/(general)/samenvatting/_utils/getContactSummary.ts
+++ b/apps/melding-form/src/app/(general)/samenvatting/_utils/getContactSummary.ts
@@ -1,0 +1,9 @@
+export const getContactSummary = (label: string, email?: string | null, phone?: string | null) => {
+  if (!email && !phone) return undefined
+
+  return {
+    description: [email, phone].filter((item) => item !== undefined && item !== null), // Filter out undefined or null items
+    key: 'contact',
+    term: label,
+  }
+}

--- a/apps/melding-form/src/app/(general)/samenvatting/_utils/getLocationSummary.test.ts
+++ b/apps/melding-form/src/app/(general)/samenvatting/_utils/getLocationSummary.test.ts
@@ -1,0 +1,26 @@
+import type { MeldingOutput } from '@meldingen/api-client'
+
+import { getLocationSummary } from './getLocationSummary'
+import { melding } from '~/mocks/data'
+
+describe('getLocationSummary', () => {
+  it('returns correct location summary', () => {
+    const result = getLocationSummary((key) => key, melding)
+
+    expect(result).toEqual({
+      description: 'Oudezijds Voorburgwal 300A, 1012GL Amsterdam',
+      key: 'location',
+      term: 'location-label',
+    })
+  })
+
+  it('returns error message when melding does not have an address', () => {
+    const result = getLocationSummary((key) => key, {} as MeldingOutput)
+
+    expect(result).toEqual({
+      description: 'errors.no-location',
+      key: 'location',
+      term: 'location-label',
+    })
+  })
+})

--- a/apps/melding-form/src/app/(general)/samenvatting/_utils/getLocationSummary.ts
+++ b/apps/melding-form/src/app/(general)/samenvatting/_utils/getLocationSummary.ts
@@ -1,0 +1,13 @@
+import type { MeldingOutput } from '@meldingen/api-client'
+
+import { getFullNLAddress } from '../../_utils/getFullNLAddress'
+
+export const getLocationSummary = (t: (key: string) => string, meldingData: MeldingOutput) => {
+  const address = getFullNLAddress(meldingData) || t('errors.no-location')
+
+  return {
+    description: address,
+    key: 'location',
+    term: t('location-label'),
+  }
+}

--- a/apps/melding-form/src/app/(general)/samenvatting/_utils/getMeldingData.test.ts
+++ b/apps/melding-form/src/app/(general)/samenvatting/_utils/getMeldingData.test.ts
@@ -1,0 +1,27 @@
+import { http, HttpResponse } from 'msw'
+
+import { getMeldingData } from './getMeldingData'
+import { melding } from '~/mocks/data'
+import { ENDPOINTS } from '~/mocks/endpoints'
+import { server } from '~/mocks/node'
+
+const mockMeldingId = '88'
+const mockToken = 'test-token'
+
+describe('getMeldingData', () => {
+  it('should return correct melding summary', async () => {
+    const result = await getMeldingData(mockMeldingId, mockToken)
+
+    expect(result).toEqual(melding)
+  })
+
+  it('should return an error message when error is returned', async () => {
+    server.use(
+      http.get(ENDPOINTS.GET_MELDING_BY_MELDING_ID_MELDER, () => HttpResponse.json('Error message', { status: 500 })),
+    )
+
+    const testFunction = async () => await getMeldingData(mockMeldingId, mockToken)
+
+    await expect(testFunction).rejects.toThrowError('Failed to fetch melding data.')
+  })
+})

--- a/apps/melding-form/src/app/(general)/samenvatting/_utils/getMeldingData.ts
+++ b/apps/melding-form/src/app/(general)/samenvatting/_utils/getMeldingData.ts
@@ -1,0 +1,12 @@
+import { getMeldingByMeldingIdMelder } from '@meldingen/api-client'
+
+export const getMeldingData = async (meldingId: string, token: string) => {
+  const { data, error } = await getMeldingByMeldingIdMelder({
+    path: { melding_id: parseInt(meldingId, 10) },
+    query: { token },
+  })
+
+  if (error) throw new Error('Failed to fetch melding data.')
+
+  return data
+}

--- a/apps/melding-form/src/app/(general)/samenvatting/_utils/getPrimaryFormSummary.test.ts
+++ b/apps/melding-form/src/app/(general)/samenvatting/_utils/getPrimaryFormSummary.test.ts
@@ -1,0 +1,56 @@
+import { http, HttpResponse } from 'msw'
+
+import { getPrimaryFormSummary } from './getPrimaryFormSummary'
+import { ENDPOINTS } from '~/mocks/endpoints'
+import { server } from '~/mocks/node'
+
+describe('getPrimaryFormSummary', () => {
+  it('returns correct primary form summary', async () => {
+    const result = await getPrimaryFormSummary('Er ligt hier veel afval op straat.')
+
+    expect(result).toEqual({
+      data: {
+        description: 'Er ligt hier veel afval op straat.',
+        key: 'primary',
+        term: 'First question',
+      },
+    })
+  })
+
+  it('returns an error message when getStaticForm returns an error', async () => {
+    server.use(http.get(ENDPOINTS.GET_STATIC_FORM, () => HttpResponse.json('Error message', { status: 500 })))
+
+    const testFunction = async () => await getPrimaryFormSummary('')
+
+    await expect(testFunction).rejects.toThrowError('Failed to fetch static forms.')
+  })
+
+  it('returns an error message when primary form id is not found', async () => {
+    server.use(
+      http.get(ENDPOINTS.GET_STATIC_FORM, () =>
+        HttpResponse.json([
+          {
+            id: '123',
+            type: 'not-primary',
+          },
+        ]),
+      ),
+    )
+
+    const testFunction = async () => await getPrimaryFormSummary('')
+
+    await expect(testFunction).rejects.toThrowError('Primary form id not found.')
+  })
+
+  it('returns an error message when getStaticFormByStaticFormId returns an error', async () => {
+    server.use(
+      http.get(ENDPOINTS.GET_STATIC_FORM_BY_STATIC_FORM_ID, () =>
+        HttpResponse.json({ detail: 'Error message' }, { status: 500 }),
+      ),
+    )
+
+    const testFunction = async () => await getPrimaryFormSummary('')
+
+    await expect(testFunction).rejects.toThrowError('Failed to fetch primary form data.')
+  })
+})

--- a/apps/melding-form/src/app/(general)/samenvatting/_utils/getPrimaryFormSummary.ts
+++ b/apps/melding-form/src/app/(general)/samenvatting/_utils/getPrimaryFormSummary.ts
@@ -1,0 +1,23 @@
+import { getStaticForm, getStaticFormByStaticFormId } from '@meldingen/api-client'
+
+export const getPrimaryFormSummary = async (description: string) => {
+  const { data: staticFormsData, error: staticFormsError } = await getStaticForm()
+
+  if (staticFormsError) throw new Error('Failed to fetch static forms.')
+
+  const primaryFormId = staticFormsData.find((form) => form.type === 'primary')?.id
+
+  if (!primaryFormId) throw new Error('Primary form id not found.')
+
+  const { data: primaryFormData, error: primaryFormError } = await getStaticFormByStaticFormId({
+    path: { static_form_id: primaryFormId },
+  })
+
+  if (primaryFormError) throw new Error('Failed to fetch primary form data.')
+
+  const primaryForm = primaryFormData.components[0]
+
+  return {
+    data: { description, key: 'primary', term: primaryForm.label },
+  }
+}

--- a/apps/melding-form/src/app/(general)/samenvatting/_utils/index.ts
+++ b/apps/melding-form/src/app/(general)/samenvatting/_utils/index.ts
@@ -1,0 +1,6 @@
+export { getAdditionalQuestionsSummary } from './getAdditionalQuestionsSummary'
+export { getAttachmentsSummary } from './getAttachmentsSummary'
+export { getContactSummary } from './getContactSummary'
+export { getLocationSummary } from './getLocationSummary'
+export { getMeldingData } from './getMeldingData'
+export { getPrimaryFormSummary } from './getPrimaryFormSummary'

--- a/apps/melding-form/src/app/(general)/samenvatting/page.tsx
+++ b/apps/melding-form/src/app/(general)/samenvatting/page.tsx
@@ -1,8 +1,6 @@
 import { getTranslations } from 'next-intl/server'
 import { cookies } from 'next/headers'
 
-import { postSummaryForm } from './actions'
-import { Summary } from './Summary'
 import {
   getAdditionalQuestionsSummary,
   getAttachmentsSummary,
@@ -10,7 +8,9 @@ import {
   getLocationSummary,
   getMeldingData,
   getPrimaryFormSummary,
-} from './utils'
+} from './_utils'
+import { postSummaryForm } from './actions'
+import { Summary } from './Summary'
 import { COOKIES, TOP_ANCHOR_ID } from '~/constants'
 
 export default async () => {

--- a/apps/melding-form/src/app/_utils/resolveClassificationRedirect.test.ts
+++ b/apps/melding-form/src/app/_utils/resolveClassificationRedirect.test.ts
@@ -1,10 +1,10 @@
 import { http, HttpResponse } from 'msw'
 
-import { TOP_ANCHOR_ID } from '../constants'
-import { form } from '../mocks/data'
-import { ENDPOINTS } from '../mocks/endpoints'
-import { server } from '../mocks/node'
-import { resolveClassificationRedirect } from './utils'
+import { resolveClassificationRedirect } from './resolveClassificationRedirect'
+import { TOP_ANCHOR_ID } from '~/constants'
+import { form } from '~/mocks/data'
+import { ENDPOINTS } from '~/mocks/endpoints'
+import { server } from '~/mocks/node'
 
 describe('resolveClassificationRedirect', () => {
   it('returns an error when getFormClassificationByClassificationId returns an error', async () => {

--- a/apps/melding-form/src/app/_utils/resolveClassificationRedirect.ts
+++ b/apps/melding-form/src/app/_utils/resolveClassificationRedirect.ts
@@ -1,6 +1,6 @@
 import { getFormClassificationByClassificationId, putMeldingByMeldingIdAnswerQuestions } from '@meldingen/api-client'
 
-import { TOP_ANCHOR_ID } from '../constants'
+import { TOP_ANCHOR_ID } from '~/constants'
 
 type ClassificationRedirectResult = { type: 'redirect'; url: string } | { error: unknown; type: 'error' }
 

--- a/apps/melding-form/src/app/back-office-entry/route.ts
+++ b/apps/melding-form/src/app/back-office-entry/route.ts
@@ -5,7 +5,7 @@ import { NextResponse } from 'next/server'
 
 import { client } from '@meldingen/api-client'
 
-import { resolveClassificationRedirect } from '../utils'
+import { resolveClassificationRedirect } from '../_utils/resolveClassificationRedirect'
 import { COOKIES } from '~/constants'
 
 // Configure the API client here, because a route handler does not pass layout.tsx.


### PR DESCRIPTION
## What

This moves some utilities in `utils.ts` files to separate files in `_utils` folders.

## Why

We've agreed to separate these utils files, in order to make them easier to test and to avoid accidental dependencies. 

Before opening a pull request, please ensure your branch is based on `main` and targets `main`.

- [x] Includes AI-assisted code via GitHub Copilot

Check requirements when they are met (strikethrough when not applicable):

- [x] Acknowledges **[team code standards](https://github.com/Amsterdam/meldingen-frontend/tree/main/docs)**
- [ ] ~~Has **unit tests** with 100% coverage (if feasible) and all test should pass~~
- [ ] ~~Has **error handling** and **loading states**~~
- [ ] ~~Is **responsive and respects WCAG**~~
- [ ] ~~**Documentation** has been updated~~
- [x] **Required PR checks** have passed

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
