### PR TITLE
Use id that really always exists for assets, post data in parallel

### DIFF
--- a/apps/melding-form/src/app/(map)/locatie/kies/_components/AssetList/AssetList.test.tsx
+++ b/apps/melding-form/src/app/(map)/locatie/kies/_components/AssetList/AssetList.test.tsx
@@ -30,8 +30,8 @@ describe('AssetList', () => {
   it('renders a list of assets', () => {
     render(<AssetList {...defaultProps} />)
 
-    expect(screen.getByText('Container-001')).toBeInTheDocument()
-    expect(screen.getByText('Container-002')).toBeInTheDocument()
+    expect(screen.getByText('container.1')).toBeInTheDocument()
+    expect(screen.getByText('container.2')).toBeInTheDocument()
 
     const restIcon = screen.getByAltText('Restafval icon')
     const glasIcon = screen.getByAltText('Glas icon')
@@ -53,7 +53,7 @@ describe('AssetList', () => {
 
     const checkboxes = screen.getAllByRole('checkbox')
 
-    expect(checkboxes[0]).toHaveAccessibleName(/Container-002/)
+    expect(checkboxes[0]).toHaveAccessibleName(/container.2/)
   })
 
   it('renders no duplicated assets', () => {
@@ -68,7 +68,7 @@ describe('AssetList', () => {
     const user = userEvent.setup()
     render(<AssetList {...defaultProps} />)
 
-    const checkbox = screen.getByRole('checkbox', { name: /Container-001/ })
+    const checkbox = screen.getByRole('checkbox', { name: /container.1/ })
 
     expect(checkbox).not.toBeChecked()
 
@@ -84,14 +84,7 @@ describe('AssetList', () => {
   it('sets notification when max selected assets is reached', async () => {
     const maxAssets = Array(5)
       .fill(containerAssets[0])
-      .map((asset, index) => ({
-        ...asset,
-        id: index,
-        properties: {
-          ...asset.properties,
-          id_nummer: index,
-        },
-      }))
+      .map((asset, index) => ({ ...asset, id: index }))
 
     const user = userEvent.setup()
     render(<AssetList {...defaultProps} selectedAssets={maxAssets} />)
@@ -107,7 +100,7 @@ describe('AssetList', () => {
     const user = userEvent.setup()
     render(<AssetList {...defaultProps} selectedAssets={[containerAssets[0]]} />)
 
-    const checkbox = screen.getByRole('checkbox', { name: /Container-001/ })
+    const checkbox = screen.getByRole('checkbox', { name: /container.1/ })
 
     await user.click(checkbox)
 
@@ -119,7 +112,7 @@ describe('AssetList', () => {
     const user = userEvent.setup()
     render(<AssetList {...defaultProps} selectedAssets={[containerAssets[0]]} />)
 
-    const checkbox = screen.getByRole('checkbox', { name: /Container-001/ })
+    const checkbox = screen.getByRole('checkbox', { name: /container.1/ })
 
     await user.click(checkbox)
 
@@ -132,7 +125,7 @@ describe('AssetList', () => {
     const user = userEvent.setup()
     render(<AssetList {...defaultProps} selectedAssets={containerAssets} />)
 
-    const checkbox = screen.getByRole('checkbox', { name: /Container-001/ })
+    const checkbox = screen.getByRole('checkbox', { name: /container.1/ })
 
     await user.click(checkbox)
 
@@ -147,7 +140,7 @@ describe('AssetList', () => {
     const user = userEvent.setup()
     render(<AssetList {...defaultProps} selectedAssets={containerAssets} />)
 
-    const checkbox = screen.getByRole('checkbox', { name: /Container-002/ })
+    const checkbox = screen.getByRole('checkbox', { name: /container.2/ })
 
     await user.click(checkbox)
 

--- a/apps/melding-form/src/app/(map)/locatie/kies/_components/AssetList/AssetList.tsx
+++ b/apps/melding-form/src/app/(map)/locatie/kies/_components/AssetList/AssetList.tsx
@@ -26,7 +26,7 @@ export type Props = {
 
 const getCheckboxLabel = (
   asset: Feature,
-  idNummer: string,
+  id: number | string,
   assetTypeIconConfig: { iconEntry?: string; iconFolder?: string },
 ) => {
   const altText = `${asset.properties?.fractie_omschrijving ?? ''} icon`.trim()
@@ -40,7 +40,7 @@ const getCheckboxLabel = (
         properties={asset.properties}
         width={32}
       />
-      <span>{idNummer}</span>
+      <span>{id}</span>
     </span>
   )
 }
@@ -92,12 +92,12 @@ export const AssetList = ({
   return (
     <ul className={styles.container}>
       {selectedAssets.map((asset) => {
-        // @ts-expect-error id_nummer always exists on asset properties
-        const publicId = asset.properties.id_nummer as string
-        const label = getCheckboxLabel(asset, publicId, assetTypeIconConfig)
+        // `id` always exists on WFS layers from the City of Amsterdam
+        const id = asset.id as number | string
+        const label = getCheckboxLabel(asset, id, assetTypeIconConfig)
 
         return (
-          <li key={publicId}>
+          <li key={id}>
             <Checkbox checked className={styles.checkbox} onChange={() => handleDeselectAsset(asset)}>
               {label}
             </Checkbox>
@@ -105,12 +105,12 @@ export const AssetList = ({
         )
       })}
       {filteredList.map((asset) => {
-        // @ts-expect-error id_nummer always exists on asset properties
-        const publicId = asset.properties.id_nummer as string
-        const label = getCheckboxLabel(asset, publicId, assetTypeIconConfig)
+        // `id` always exists on WFS layers from the City of Amsterdam
+        const id = asset.id as number | string
+        const label = getCheckboxLabel(asset, id, assetTypeIconConfig)
 
         return (
-          <li key={publicId}>
+          <li key={id}>
             <Checkbox checked={false} className={styles.checkbox} onChange={() => handleSelectAsset(asset)}>
               {label}
             </Checkbox>

--- a/apps/melding-form/src/app/(map)/locatie/kies/actions.ts
+++ b/apps/melding-form/src/app/(map)/locatie/kies/actions.ts
@@ -27,10 +27,12 @@ export const postCoordinatesAndAssets = async (
   const selectedAssetIds = safeJSONParse<number[], number[]>(selectedAssetIdsRaw, [])
   const cookieStore = await cookies()
 
-  const meldingId = cookieStore.get(COOKIES.ID)?.value
+  const meldingIdString = cookieStore.get(COOKIES.ID)?.value
   const token = cookieStore.get(COOKIES.TOKEN)?.value
 
-  if (!meldingId || !token) return redirect(`/cookie-storing#${TOP_ANCHOR_ID}`)
+  if (!meldingIdString || !token) return redirect(`/cookie-storing#${TOP_ANCHOR_ID}`)
+
+  const meldingId = parseInt(meldingIdString, 10)
 
   const addressFormData = formData.get('address')
   const coordinatesFormData = formData.get('coordinates')
@@ -47,7 +49,7 @@ export const postCoordinatesAndAssets = async (
       selectedAssetIds.map((id) =>
         postMeldingByMeldingIdAsset({
           body: { asset_type_id, external_id: String(id) },
-          path: { melding_id: parseInt(meldingId, 10) },
+          path: { melding_id: meldingId },
           query: { token },
         }),
       ),
@@ -95,7 +97,7 @@ export const postCoordinatesAndAssets = async (
       properties: {},
       type: 'Feature',
     },
-    path: { melding_id: parseInt(meldingId, 10) },
+    path: { melding_id: meldingId },
     query: { token },
   })
 
@@ -109,7 +111,7 @@ export const postCoordinatesAndAssets = async (
   // Normally, we would set the melding state to 'location_submitted' there, but for those users we do it here.
   if (source === 'back-office') {
     const { error: stateError } = await putMeldingByMeldingIdSubmitLocation({
-      path: { melding_id: parseInt(meldingId, 10) },
+      path: { melding_id: meldingId },
       query: { token },
     })
 

--- a/apps/melding-form/src/app/(map)/locatie/kies/actions.ts
+++ b/apps/melding-form/src/app/(map)/locatie/kies/actions.ts
@@ -43,19 +43,18 @@ export const postCoordinatesAndAssets = async (
       return { errorMessage: t('errors.assets-post-failed') }
     }
 
-    for (const id of selectedAssetIds) {
-      const { error } = await postMeldingByMeldingIdAsset({
-        body: {
-          asset_type_id,
-          external_id: String(id),
-        },
-        path: { melding_id: parseInt(meldingId, 10) },
-        query: { token },
-      })
+    const results = await Promise.all(
+      selectedAssetIds.map((id) =>
+        postMeldingByMeldingIdAsset({
+          body: { asset_type_id, external_id: String(id) },
+          path: { melding_id: parseInt(meldingId, 10) },
+          query: { token },
+        }),
+      ),
+    )
 
-      if (error) {
-        return { errorMessage: t('errors.assets-post-failed') }
-      }
+    if (results.some(({ error }) => error)) {
+      return { errorMessage: t('errors.assets-post-failed') }
     }
   }
 


### PR DESCRIPTION
## What

This PR does 2 things:

- It uses an `id` for assets that always exists. Previously we used `asset.properties.id_nummer`, but that does not exist for Klokken for example.
- It posts asset data in parallel instead of sequential

## Why

I ran into these issues when trying to fix [this ticket](https://gemeente-amsterdam.atlassian.net/browse/SIG-7365). This doesn't fix it, but they slightly improve the existing code. 

Before opening a pull request, please ensure your branch is based on `main` and targets `main`.

- [x] Includes AI-assisted code via GitHub Copilot

Check requirements when they are met (strikethrough when not applicable):

- [x] Acknowledges **[team code standards](https://github.com/Amsterdam/meldingen-frontend/tree/main/docs)**
- [x] Has **unit tests** with 100% coverage (if feasible) and all test should pass
- [ ] ~~Has **error handling** and **loading states**~~
- [ ] ~~Is **responsive and respects WCAG**~~
- [ ] ~~**Documentation** has been updated~~
- [x] **Required PR checks** have passed

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
