### PR TITLE
Allow adding notes to Melding

### DIFF
--- a/apps/back-office/src/app/melding/[meldingId]/Detail.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/Detail.tsx
@@ -99,6 +99,7 @@ export const Detail = ({
               </dl>
             )}
             <dl className={clsx(styles.horizontalDescriptionList, styles.cardTall)}>
+              <AmsNextLink href={`/melding/${publicId}/notities/toevoegen`}>Voeg notitie toe</AmsNextLink>
               {meldingData.map(({ description, key, link, term }) => (
                 <Fragment key={key}>
                   <dt className={styles.term}>{term}</dt>

--- a/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/AddNote.module.css
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/AddNote.module.css
@@ -1,0 +1,9 @@
+.alert {
+  outline-offset: var(--ams-focus-outline-offset);
+}
+
+.whiteField {
+  background-color: var(--ams-color-background);
+  padding-block: var(--ams-space-l);
+  padding-inline: var(--ams-space-l);
+}

--- a/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/AddNote.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/AddNote.test.tsx
@@ -1,0 +1,105 @@
+import type { Mock } from 'vitest'
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useActionState } from 'react'
+
+import type { FormState } from './actions'
+
+import { AddNote } from './AddNote'
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...(typeof actual === 'object' ? actual : {}),
+    useActionState: vi.fn().mockReturnValue([{}, vi.fn()]),
+  }
+})
+
+const defaultProps = {
+  meldingId: 123,
+}
+
+describe('AddNote', () => {
+  beforeEach(() => {
+    ;(useActionState as Mock).mockReturnValue([{}, vi.fn()])
+  })
+
+  it('renders the backlink', () => {
+    render(<AddNote {...defaultProps} />)
+
+    const backLink = screen.getByRole('link', { name: 'back-link' })
+    expect(backLink).toBeInTheDocument()
+    expect(backLink).toHaveAttribute('href', '/melding/123')
+  })
+
+  it('renders the component with the correct title and textarea', () => {
+    render(<AddNote {...defaultProps} />)
+
+    expect(screen.getByRole('heading', { name: 'title' })).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: 'label' })).toBeInTheDocument()
+  })
+
+  it('renders the cancel link', () => {
+    render(<AddNote {...defaultProps} />)
+
+    const cancelLink = screen.getByRole('link', { name: 'cancel-link' })
+
+    expect(cancelLink).toBeInTheDocument()
+    expect(cancelLink).toHaveAttribute('href', '/melding/123')
+  })
+
+  it('renders a validation alert and keeps the submitted text', () => {
+    const formState: FormState = {
+      textFromAction: 'Existing note',
+      validationErrors: [{ key: 'text', message: 'errors.validation.required' }],
+    }
+    ;(useActionState as Mock).mockReturnValue([formState, vi.fn()])
+
+    render(<AddNote {...defaultProps} />)
+
+    const alert = screen.getByRole('alert', { name: 'errors.validation.heading' })
+    expect(alert).toBeInTheDocument()
+    expect(alert).toHaveTextContent('errors.validation.required')
+
+    expect(screen.getByRole('textbox', { name: 'label' })).toHaveValue('Existing note')
+  })
+
+  it('renders a system error alert', () => {
+    const formState: FormState = {
+      systemError: 'Something went wrong',
+      textFromAction: 'Existing note',
+    }
+    ;(useActionState as Mock).mockReturnValue([formState, vi.fn()])
+
+    render(<AddNote {...defaultProps} />)
+
+    const alert = screen.getByRole('alert', { name: 'errors.system.heading' })
+    expect(alert).toBeInTheDocument()
+    expect(alert).toHaveTextContent('Something went wrong')
+  })
+
+  it('updates the character count when the user types in the textarea', async () => {
+    const user = userEvent.setup()
+
+    render(<AddNote {...defaultProps} />)
+
+    await user.type(screen.getByRole('textbox', { name: 'label' }), 'Hello')
+
+    expect(screen.getByText('5 van 3000 tekens')).toBeInTheDocument()
+  })
+
+  it('submits the form when the submit button is clicked', async () => {
+    const user = userEvent.setup()
+
+    const mockFormAction = vi.fn()
+    ;(useActionState as Mock).mockReturnValue([{}, mockFormAction])
+
+    render(<AddNote {...defaultProps} />)
+
+    const submitButton = screen.getByRole('button', { name: 'submit-button' })
+    await user.click(submitButton)
+
+    expect(mockFormAction).toHaveBeenCalled()
+  })
+})

--- a/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/AddNote.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/AddNote.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import {
+  ActionGroup,
+  Alert,
+  Button,
+  CharacterCount,
+  ErrorMessage,
+  Field,
+  Grid,
+  Heading,
+  Label,
+  Paragraph,
+  TextArea,
+} from '@amsterdam/design-system-react'
+import { clsx } from 'clsx'
+import { useTranslations } from 'next-intl'
+import Form from 'next/form'
+import { useActionState, useEffect, useRef, useState } from 'react'
+
+import { getAriaDescribedBy } from '@meldingen/form-renderer'
+
+import type { FormState } from './actions'
+
+import { BackLink } from '../../_components/BackLink'
+import { CancelLink } from '../../_components/CancelLink'
+import { postAddNoteForm } from './actions'
+
+import styles from './AddNote.module.css'
+
+type Props = {
+  meldingId: number
+}
+
+const initialState: FormState = {}
+
+const MAX_NOTE_LENGTH = 3000
+
+export const AddNote = ({ meldingId }: Props) => {
+  const errorAlertRef = useRef<HTMLDivElement>(null)
+  const textAreaRef = useRef<HTMLTextAreaElement>(null)
+
+  const postAddNoteFormWithMeldingId = postAddNoteForm.bind(null, { meldingId })
+
+  const [{ systemError, textFromAction, validationErrors }, formAction] = useActionState(
+    postAddNoteFormWithMeldingId,
+    initialState,
+  )
+
+  const t = useTranslations('add-note')
+
+  const textErrorMessage = validationErrors?.find((error) => error.key === 'text')?.message
+  const textToDisplay = textFromAction ?? ''
+
+  const [charCount, setCharCount] = useState(textToDisplay.length)
+
+  useEffect(() => {
+    setCharCount(textToDisplay.length)
+  }, [textToDisplay])
+
+  useEffect(() => {
+    if (!validationErrors?.length && !systemError) return
+
+    if (systemError) {
+      // TODO: Log the error to an error reporting service
+      // eslint-disable-next-line no-console
+      console.error(systemError)
+    }
+
+    if (errorAlertRef.current) {
+      errorAlertRef.current.focus()
+    }
+  }, [systemError, validationErrors])
+
+  let documentTitle = t('metadata.title')
+
+  if (textErrorMessage) {
+    documentTitle = `${textErrorMessage} - ${t('metadata.title')}`
+  } else if (systemError) {
+    documentTitle = `${t('errors.system.heading')} - ${t('metadata.title')}`
+  }
+
+  return (
+    <div className="ams-page__area--body">
+      <title>{documentTitle}</title>
+      <BackLink href={`/melding/${meldingId}`}>{t('back-link')}</BackLink>
+      <Grid as="main" gapVertical="large">
+        <Grid.Cell appearance="transparent" span={{ narrow: 4, medium: 6, wide: 6 }}>
+          {(validationErrors?.length || systemError) && (
+            <Alert
+              className={clsx('ams-mb-m', styles.alert)}
+              heading={
+                systemError
+                  ? t('errors.system.heading')
+                  : validationErrors?.find((error) => error.key === 'text')?.message
+                    ? t('errors.validation.heading')
+                    : t('errors.system.heading')
+              }
+              headingLevel={2}
+              ref={errorAlertRef}
+              role="alert"
+              severity="error"
+              tabIndex={-1}
+            >
+              <Paragraph>
+                {systemError
+                  ? systemError
+                  : validationErrors?.find((error) => error.key === 'text')?.message
+                    ? validationErrors.find((error) => error.key === 'text')?.message
+                    : ''}
+              </Paragraph>
+            </Alert>
+          )}
+
+          <Heading className="ams-mb-m" level={1}>
+            {t('title')}
+          </Heading>
+
+          <Form action={formAction} noValidate>
+            <Field className={clsx(styles.whiteField, 'ams-mb-m')} invalid={Boolean(textErrorMessage)}>
+              <Label htmlFor="text">{t('label')}</Label>
+              {textErrorMessage && <ErrorMessage id="text-error">{textErrorMessage}</ErrorMessage>}
+              <TextArea
+                aria-describedby={getAriaDescribedBy('text', undefined, textErrorMessage)}
+                aria-required="true"
+                defaultValue={textToDisplay}
+                id="text"
+                invalid={Boolean(textErrorMessage)}
+                key={textToDisplay}
+                maxLength={MAX_NOTE_LENGTH}
+                minLength={1}
+                name="text"
+                onChange={() => {
+                  if (textAreaRef.current) {
+                    setCharCount(textAreaRef.current.value.length)
+                  }
+                }}
+                ref={textAreaRef}
+                rows={8}
+              />
+              <CharacterCount length={charCount} maxLength={MAX_NOTE_LENGTH} />
+            </Field>
+
+            <ActionGroup>
+              <Button type="submit">{t('submit-button')}</Button>
+              <CancelLink href={`/melding/${meldingId}`}>{t('cancel-link')}</CancelLink>
+            </ActionGroup>
+          </Form>
+        </Grid.Cell>
+      </Grid>
+    </div>
+  )
+}

--- a/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/actions.test.ts
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/actions.test.ts
@@ -1,0 +1,75 @@
+import { http, HttpResponse } from 'msw'
+import { redirect } from 'next/navigation'
+
+import { postAddNoteForm } from './actions'
+import { ENDPOINTS } from '~/mocks/endpoints'
+import { server } from '~/mocks/node'
+
+const defaultArgs = { meldingId: 123 }
+
+describe('postAddNoteForm', () => {
+  it('returns a validation error when the note is empty', async () => {
+    const formData = new FormData()
+    formData.append('text', '')
+
+    const result = await postAddNoteForm(defaultArgs, null, formData)
+
+    expect(result).toEqual({
+      textFromAction: '',
+      validationErrors: [{ key: 'text', message: 'errors.validation.required' }],
+    })
+    expect(redirect).not.toHaveBeenCalledWith('/melding/123')
+  })
+
+  it('returns a validation error when the API responds with 422', async () => {
+    server.use(
+      http.post(ENDPOINTS.POST_MELDING_BY_MELDING_ID_NOTE, () =>
+        HttpResponse.json(
+          {
+            detail: [{ loc: ['body', 'text'], msg: 'Validation error', type: 'value_error' }],
+          },
+          { status: 422 },
+        ),
+      ),
+    )
+
+    const formData = new FormData()
+    formData.append('text', 'Hello world')
+
+    const result = await postAddNoteForm(defaultArgs, null, formData)
+
+    expect(result).toEqual({
+      textFromAction: 'Hello world',
+      validationErrors: [{ key: 'text', message: 'Validation error' }],
+    })
+    expect(redirect).not.toHaveBeenCalledWith('/melding/123')
+  })
+
+  it('returns a system error when the API responds with an error', async () => {
+    server.use(
+      http.post(ENDPOINTS.POST_MELDING_BY_MELDING_ID_NOTE, () =>
+        HttpResponse.json({ detail: 'Error message' }, { status: 500 }),
+      ),
+    )
+
+    const formData = new FormData()
+    formData.append('text', 'Hello world')
+
+    const result = await postAddNoteForm(defaultArgs, null, formData)
+
+    expect(result).toEqual({
+      systemError: 'Error message',
+      textFromAction: 'Hello world',
+    })
+    expect(redirect).not.toHaveBeenCalledWith('/melding/123')
+  })
+
+  it('redirects on success', async () => {
+    const formData = new FormData()
+    formData.append('text', 'Hello world')
+
+    await postAddNoteForm(defaultArgs, null, formData)
+
+    expect(redirect).toHaveBeenCalledWith('/melding/123')
+  })
+})

--- a/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/actions.ts
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/actions.ts
@@ -1,0 +1,60 @@
+'use server'
+
+import { getTranslations } from 'next-intl/server'
+import { redirect } from 'next/navigation'
+
+import { postMeldingByMeldingIdNote } from '~/app/_api-client/proxy'
+import { handleApiError } from '~/app/_utils/handleApiError'
+
+const MIN_NOTE_LENGTH = 1
+const MAX_NOTE_LENGTH = 3000
+
+export type FormState = {
+  systemError?: string
+  textFromAction?: string
+  validationErrors?: { key: string; message: string }[]
+}
+
+type Args = {
+  meldingId: number
+}
+
+export const postAddNoteForm = async ({ meldingId }: Args, _: unknown, formData: FormData): Promise<FormState> => {
+  const t = await getTranslations('add-note')
+
+  const text = String(formData.get('text') ?? '')
+  const redirectPath = `/melding/${meldingId}`
+
+  if (text.length < MIN_NOTE_LENGTH) {
+    return {
+      textFromAction: text,
+      validationErrors: [{ key: 'text', message: t('errors.validation.required') }],
+    }
+  } else if (text.length > MAX_NOTE_LENGTH) {
+    return {
+      textFromAction: text,
+      validationErrors: [{ key: 'text', message: t('errors.validation.max-length') }],
+    }
+  } else {
+    const { error, response } = await postMeldingByMeldingIdNote({
+      body: { text },
+      path: { melding_id: meldingId },
+    })
+
+    if (response?.status === 422) {
+      return {
+        textFromAction: text,
+        validationErrors: [{ key: 'text', message: handleApiError(error) }],
+      }
+    }
+
+    if (error) {
+      return {
+        systemError: handleApiError(error),
+        textFromAction: text,
+      }
+    }
+
+    redirect(redirectPath)
+  }
+}

--- a/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/page.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/page.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+
+import Page from './page'
+
+vi.mock('./AddNote', () => ({
+  AddNote: vi.fn(() => <div>AddNote Component</div>),
+}))
+
+describe('Page', () => {
+  it('renders the AddNote component when data is available', async () => {
+    const params = Promise.resolve({ meldingId: 123 })
+
+    const result = await Page({ params })
+
+    render(result)
+
+    expect(screen.getByText('AddNote Component')).toBeInTheDocument()
+  })
+})

--- a/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/page.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/page.tsx
@@ -1,0 +1,11 @@
+import { AddNote } from './AddNote'
+
+type Params = {
+  params: Promise<{ meldingId: number }>
+}
+
+export default async ({ params }: Params) => {
+  const { meldingId } = await params
+
+  return <AddNote meldingId={meldingId} />
+}

--- a/apps/back-office/src/mocks/endpoints.ts
+++ b/apps/back-office/src/mocks/endpoints.ts
@@ -19,6 +19,7 @@ export const ENDPOINTS = {
   PATCH_MELDING_BY_MELDING_ID_MELDER: '/melding/:id/melder',
 
   POST_MELDING: '/melding',
+  POST_MELDING_BY_MELDING_ID_NOTE: '/melding/:id/note',
 
   PUT_MELDING_BY_MELDING_ID_CANCEL: '/melding/:id/cancel',
   PUT_MELDING_BY_MELDING_ID_COMPLETE: '/melding/:id/complete',

--- a/apps/back-office/src/mocks/handlers.ts
+++ b/apps/back-office/src/mocks/handlers.ts
@@ -52,6 +52,15 @@ export const handlers = [
       token: 'test-token',
     }),
   ),
+  http.post(ENDPOINTS.POST_MELDING_BY_MELDING_ID_NOTE, () =>
+    HttpResponse.json(
+      {
+        created_at: '2025-05-26T11:56:34.081Z',
+        id: 1,
+      },
+      { status: 201 },
+    ),
+  ),
 
   http.put(ENDPOINTS.PUT_MELDING_BY_MELDING_ID_CANCEL, () => new HttpResponse()),
   http.put(ENDPOINTS.PUT_MELDING_BY_MELDING_ID_COMPLETE, () => new HttpResponse()),

--- a/apps/back-office/translations/nl.json
+++ b/apps/back-office/translations/nl.json
@@ -150,6 +150,27 @@
       }
     }
   },
+  "add-note": {
+    "metadata": {
+      "title": "Notitie toevoegen - Gemeente Amsterdam"
+    },
+    "back-link": "Meldingdetails",
+    "title": "Voeg notitie toe",
+    "label": "Notitie",
+    "submit-button": "Voeg notitie toe",
+    "cancel-link": "Annuleer",
+    "errors": {
+      "validation": {
+        "heading": "Verbeter de fouten voor u verder gaat",
+        "required": "Vul een notitie in.",
+        "max-length": "Een notitie mag maximaal 3000 tekens bevatten."
+      },
+      "system": {
+        "heading": "De notitie kan niet worden toegevoegd",
+        "description": "Probeer het later opnieuw."
+      }
+    }
+  },
   "shared": {
     "menu": {
       "melding-form": "Melden",


### PR DESCRIPTION
## What

Allow Behandelaar to add notes to Melding.

The ticket says the following:

- Add a page to `/melding` in the Back Office. The url should be `/melding/[meldingId]/notities/toevoegen`
- The page should contain a form with a textarea. On submit the contents of the textarea should be posted using `postMeldingByMeldingIdNote`.
- The user should submit at least 1 and maximum 3000 characters of text.
- It should have unit tests.
- On submit, the user should be redirected to `/melding/[meldingId]`.

You can find the design [here](https://www.figma.com/design/aYBher5O2SB1bBUjZcgu0e/%E2%9C%8F%EF%B8%8F-V2-backoffice?node-id=2187-45977&m=dev).

## Why

Behandelaren should be able to do this, but we hadn't built it yet.

Ticket: [SIG-7375](https://gemeente-amsterdam.atlassian.net/browse/SIG-7375)

Before opening a pull request, please ensure your branch is based on `main` and targets `main`.

- [x] Includes AI-assisted code via GitHub Copilot

Check requirements when they are met (strikethrough when not applicable):

- [x] Acknowledges **[team code standards](https://github.com/Amsterdam/meldingen-frontend/tree/main/docs)**
- [x] Has **unit tests** with 100% coverage (if feasible) and all test should pass
- [x] Has **error handling** and **loading states**
- [x] Is **responsive and respects WCAG**
- [ ] ~~**Documentation** has been updated~~
- [x] **Required PR checks** have passed

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-7375]: https://gemeente-amsterdam.atlassian.net/browse/SIG-7375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ