### PR TITLE
Translate invalid form alert title for notes

### DIFF
--- a/apps/back-office/src/app/_components/InvalidFormAlert.tsx
+++ b/apps/back-office/src/app/_components/InvalidFormAlert.tsx
@@ -6,10 +6,11 @@ import { InvalidFormAlert as UIInvalidFormAlert } from '@meldingen/ui'
 
 type Props = {
   ref: RefObject<HTMLDivElement | null>
+  title?: string
   validationErrors: { key: string; message: string }[]
 }
 
-export const InvalidFormAlert = ({ ref, validationErrors }: Props) => {
+export const InvalidFormAlert = ({ ref, title, validationErrors }: Props) => {
   const t = useTranslations('melding-form.errors')
 
   return (
@@ -19,7 +20,7 @@ export const InvalidFormAlert = ({ ref, validationErrors }: Props) => {
         id: `#${error.key}`,
         label: error.message,
       }))}
-      heading={t('invalid-form-alert-title')}
+      heading={title || t('invalid-form-alert-title')}
       headingLevel={2}
       ref={ref}
     />

--- a/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/AddNote.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/AddNote.tsx
@@ -67,7 +67,13 @@ export const AddNote = ({ meldingId }: { meldingId: number }) => {
       <Grid as="main" gapVertical="large">
         <Grid.Cell appearance="transparent" span={{ narrow: 4, medium: 6, wide: 6 }}>
           {Boolean(systemError) && <SystemErrorAlert ref={systemErrorAlertRef} />}
-          {validationErrors && <InvalidFormAlert ref={invalidFormAlertRef} validationErrors={validationErrors} />}
+          {validationErrors && (
+            <InvalidFormAlert
+              ref={invalidFormAlertRef}
+              title={t('invalid-form-alert-title')}
+              validationErrors={validationErrors}
+            />
+          )}
           <Heading className="ams-mb-m" level={1}>
             {t('title')}
           </Heading>

--- a/apps/back-office/translations/nl.json
+++ b/apps/back-office/translations/nl.json
@@ -155,6 +155,7 @@
       "title": "Notitie toevoegen - Gemeente Amsterdam"
     },
     "back-link": "Meldingdetails",
+    "invalid-form-alert-title": "Verbeter de fouten om uw notitie toe te voegen",
     "title": "Notitie toevoegen",
     "label": "Notitie toevoegen",
     "submit-button": "Notitie toevoegen",


### PR DESCRIPTION
## What

This add a specific title for the invalid form alert you can get when adding notes. 

## Why

The title was quite generic, this is more specific.

See also [this comment](https://gemeente-amsterdam.atlassian.net/browse/SIG-7375?focusedCommentId=588883)

Before opening a pull request, please ensure your branch is based on `main` and targets `main`.

- [ ] Includes AI-assisted code via GitHub Copilot

Check requirements when they are met (strikethrough when not applicable):

- [x] Acknowledges **[team code standards](https://github.com/Amsterdam/meldingen-frontend/tree/main/docs)**
- [ ] ~~Has **unit tests** with 100% coverage (if feasible) and all test should pass~~
- [ ] ~~Has **error handling** and **loading states**~~
- [ ] ~~Is **responsive and respects WCAG**~~
- [ ] ~~**Documentation** has been updated~~
- [x] **Required PR checks** have passed

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
