### PR TITLE
adds health 200 page

### DIFF
--- a/apps/melding-form/src/app/(general)/health/route.test.ts
+++ b/apps/melding-form/src/app/(general)/health/route.test.ts
@@ -1,0 +1,10 @@
+import { GET } from './route'
+
+describe('GET', () => {
+  it('returns a 200 response', async () => {
+    const response = await GET()
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('OK')
+  })
+})

--- a/apps/melding-form/src/app/(general)/health/route.ts
+++ b/apps/melding-form/src/app/(general)/health/route.ts
@@ -1,0 +1,3 @@
+import { NextResponse } from 'next/server'
+
+export const GET = async () => new NextResponse('OK', { status: 200 })


### PR DESCRIPTION
## What

Adds a health page that always returns 200. We will add a password to the rest of the pages, and we need a page for the infra to know that the frontend is healthy. We will use this page for that purpose.

## Why

(What problem does this solve? Link to ADR if applicable)

Ticket: [SIG-1234](https://gemeente-amsterdam.atlassian.net/browse/SIG-1234)

Before opening a pull request, please ensure your branch is based on `main` and targets `main`.

- [x] Includes AI-assisted code via GitHub Copilot

Check requirements when they are met (strikethrough when not applicable):

- [x] Acknowledges **[team code standards](https://github.com/Amsterdam/meldingen-frontend/tree/main/docs)**
- [x] Has **unit tests** with 100% coverage (if feasible) and all test should pass
- [ ] Has **error handling** and **loading states**
- [x] Is **responsive and respects WCAG**
- [ ] **Documentation** has been updated
- [x] **Required PR checks** have passed

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
