### PR TITLE
Link back to detail page from add note page

### DIFF
--- a/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/AddNote.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/AddNote.test.tsx
@@ -22,7 +22,7 @@ describe('AddNote', () => {
 
     const backLink = screen.getByRole('link', { name: 'back-link' })
     expect(backLink).toBeInTheDocument()
-    expect(backLink).toHaveAttribute('href', '/melding/123/notities')
+    expect(backLink).toHaveAttribute('href', '/melding/123')
   })
 
   it('renders the correct title', () => {
@@ -44,7 +44,7 @@ describe('AddNote', () => {
 
     const cancelLink = screen.getByRole('link', { name: 'cancel-link' })
     expect(cancelLink).toBeInTheDocument()
-    expect(cancelLink).toHaveAttribute('href', '/melding/123/notities')
+    expect(cancelLink).toHaveAttribute('href', '/melding/123')
   })
 
   it('displays a system error alert when there is one', () => {

--- a/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/AddNote.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/AddNote.tsx
@@ -54,7 +54,7 @@ export const AddNote = ({ meldingId }: { meldingId: number }) => {
 
   return (
     <div className="ams-page__area--body">
-      <BackLink href={`/melding/${meldingId}/notities`}>{t('back-link')}</BackLink>
+      <BackLink href={`/melding/${meldingId}`}>{t('back-link')}</BackLink>
       <Grid as="main" gapVertical="large">
         <Grid.Cell appearance="transparent" span={{ narrow: 4, medium: 6, wide: 6 }}>
           {Boolean(systemError) && <SystemErrorAlert ref={systemErrorAlertRef} />}
@@ -86,7 +86,7 @@ export const AddNote = ({ meldingId }: { meldingId: number }) => {
             </div>
             <ActionGroup>
               <Button type="submit">{t('submit-button')}</Button>
-              <CancelLink href={`/melding/${meldingId}/notities`}>{t('cancel-link')}</CancelLink>
+              <CancelLink href={`/melding/${meldingId}`}>{t('cancel-link')}</CancelLink>
             </ActionGroup>
           </Form>
         </Grid.Cell>


### PR DESCRIPTION
## What

This changes the backlink and cancel link on the add note page, to link back to the melding detail page instead of the note overview page.

## Why

I discussed this with UX, the intention is that you go back to the detail page when you cancel adding a note.

Before opening a pull request, please ensure your branch is based on `main` and targets `main`.

- [ ] Includes AI-assisted code via GitHub Copilot

Check requirements when they are met (strikethrough when not applicable):

- [x] Acknowledges **[team code standards](https://github.com/Amsterdam/meldingen-frontend/tree/main/docs)**
- [x] Has **unit tests** with 100% coverage (if feasible) and all test should pass
- [ ] ~~Has **error handling** and **loading states**~~
- [ ] ~~Is **responsive and respects WCAG**~~
- [ ] ~~**Documentation** has been updated~~
- [x] **Required PR checks** have passed

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
