### PR TITLE
Add update note page and link to it from note overview

### DIFF
--- a/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.module.css
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.module.css
@@ -2,31 +2,3 @@
   gap: var(--ams-space-m);
   margin-block-end: var(--ams-space-m);
 }
-
-.note {
-  background-color: var(--ams-color-background);
-  display: flex;
-  flex-direction: column;
-  gap: var(--ams-space-s);
-  padding-block: var(--ams-space-m);
-  padding-inline: var(--ams-space-m);
-}
-
-.metadata {
-  display: flex;
-  flex-direction: column;
-}
-
-.time {
-  font-weight: var(--ams-typography-body-text-bold-font-weight);
-}
-
-.editedVisualText {
-  color: var(--ams-color-text-secondary);
-  display: inline-block;
-  font-weight: var(--ams-typography-body-text-bold-font-weight);
-}
-
-.link {
-  inline-size: fit-content;
-}

--- a/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.module.css
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.module.css
@@ -5,6 +5,9 @@
 
 .note {
   background-color: var(--ams-color-background);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ams-space-s);
   padding-block: var(--ams-space-m);
   padding-inline: var(--ams-space-m);
 }
@@ -12,9 +15,12 @@
 .metadata {
   display: flex;
   flex-direction: column;
-  margin-block-end: var(--ams-space-s);
 }
 
 .time {
   font-weight: var(--ams-typography-body-text-bold-font-weight);
+}
+
+.link {
+  inline-size: fit-content;
 }

--- a/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.module.css
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.module.css
@@ -21,6 +21,12 @@
   font-weight: var(--ams-typography-body-text-bold-font-weight);
 }
 
+.editedVisualText {
+  color: var(--ams-color-text-secondary);
+  display: inline-block;
+  font-weight: var(--ams-typography-body-text-bold-font-weight);
+}
+
 .link {
   inline-size: fit-content;
 }

--- a/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.test.tsx
@@ -48,4 +48,14 @@ describe('NotesOverview', () => {
     expect(screen.getByText('another@example.com')).toBeInTheDocument()
     expect(screen.getByText('05-03-2024 16:07')).toBeInTheDocument()
   })
+
+  it('shows a deleted note message when the note text is empty', () => {
+    const notes = [
+      { created_at: '2024-03-05T14:07:00Z', id: 1, text: '', user: { email: 'test@example.com' } },
+    ] as NoteRetrieveOutput[]
+
+    render(<NotesOverview {...defaultProps} notes={notes} />)
+
+    expect(screen.getByText('deleted-note')).toBeInTheDocument()
+  })
 })

--- a/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.test.tsx
@@ -2,13 +2,7 @@ import { render, screen } from '@testing-library/react'
 
 import type { NoteRetrieveOutput } from '@meldingen/api-client'
 
-import { formatDateTime, NotesOverview } from './NotesOverview'
-
-describe('formatDateTime', () => {
-  it('formats a date string correctly', () => {
-    expect(formatDateTime('2024-03-05T08:09:00Z')).toBe('05-03-2024 09:09')
-  })
-})
+import { NotesOverview } from './NotesOverview'
 
 const defaultProps = {
   currentUserId: 1,
@@ -28,96 +22,26 @@ describe('NotesOverview', () => {
     expect(title).toBeInTheDocument()
   })
 
-  it('renders notes when provided', () => {
+  it('renders a list of notes', () => {
     const notes = [
-      { created_at: '2024-03-05T14:07:00Z', id: 1, text: 'This is a test note.', user: { email: 'test@example.com' } },
       {
-        created_at: '2024-03-05T15:07:00Z',
+        created_at: '2024-03-05T14:07:00Z',
+        id: 1,
+        text: 'This is a test note.',
+        user: { email: 'test@example.com' },
+      },
+      {
+        created_at: '2024-04-05T14:07:00Z',
         id: 2,
         text: 'This is another test note.',
-        user: { email: 'another@example.com' },
+        user: { email: 'test@example.com' },
       },
     ] as NoteRetrieveOutput[]
 
     render(<NotesOverview {...defaultProps} notes={notes} />)
 
     expect(screen.getByText('This is a test note.')).toBeInTheDocument()
-    expect(screen.getByText('test@example.com')).toBeInTheDocument()
-    expect(screen.getByText('05-03-2024 15:07')).toBeInTheDocument()
-
     expect(screen.getByText('This is another test note.')).toBeInTheDocument()
-    expect(screen.getByText('another@example.com')).toBeInTheDocument()
-    expect(screen.getByText('05-03-2024 16:07')).toBeInTheDocument()
-  })
-
-  it('does not show an edit link for notes that do not belong to the current user', () => {
-    const notes = [
-      {
-        created_at: '2024-03-05T14:07:00Z',
-        id: 1,
-        text: 'This is a test note.',
-        user: { email: 'test@example.com', id: 2 },
-      },
-    ] as NoteRetrieveOutput[]
-
-    render(<NotesOverview {...defaultProps} notes={notes} />)
-
-    const editLink = screen.queryByRole('link', { name: 'edit-link' })
-
-    expect(editLink).not.toBeInTheDocument()
-  })
-
-  it('shows an edit link for notes that belong to the current user', () => {
-    const notes = [
-      {
-        created_at: '2024-03-05T14:07:00Z',
-        id: 1,
-        text: 'This is a test note.',
-        user: { email: 'test@example.com', id: 1 },
-      },
-    ] as NoteRetrieveOutput[]
-
-    render(<NotesOverview {...defaultProps} notes={notes} />)
-
-    const editLink = screen.getByRole('link', { name: 'edit-link' })
-
-    expect(editLink).toBeInTheDocument()
-  })
-
-  it('shows a deleted note message when the note text is empty', () => {
-    const notes = [
-      { created_at: '2024-03-05T14:07:00Z', id: 1, text: '', user: { email: 'test@example.com' } },
-    ] as NoteRetrieveOutput[]
-
-    render(<NotesOverview {...defaultProps} notes={notes} />)
-
-    expect(screen.getByText('deleted-note')).toBeInTheDocument()
-  })
-
-  it('lets a user know when a note was edited', () => {
-    const notes = [
-      {
-        created_at: '2024-03-05T14:07:00Z',
-        id: 1,
-        text: 'This is an edited test note.',
-        updated_at: '2024-03-05T15:07:00Z',
-        user: { email: 'test@example.com', id: 2 },
-      },
-      {
-        created_at: '2024-03-05T16:07:00Z',
-        id: 2,
-        text: 'This note was not edited.',
-        updated_at: '2024-03-05T16:07:00Z',
-        user: { email: 'another@example.com', id: 3 },
-      },
-    ] as NoteRetrieveOutput[]
-
-    render(<NotesOverview {...defaultProps} notes={notes} />)
-
-    const visualOnlyEditedText = screen.getByText('edited', { exact: true, selector: 'span' })
-    const visuallyHiddenEditedText = screen.getByText('visually-hidden-texts.edited')
-
-    expect(visualOnlyEditedText).toBeInTheDocument()
-    expect(visuallyHiddenEditedText).toBeInTheDocument()
+    expect(screen.getAllByText('test@example.com')).toHaveLength(2)
   })
 })

--- a/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.test.tsx
@@ -11,6 +11,7 @@ describe('formatDateTime', () => {
 })
 
 const defaultProps = {
+  currentUserId: 1,
   meldingId: 123,
   notes: [],
   publicId: 'B100AA',
@@ -47,6 +48,40 @@ describe('NotesOverview', () => {
     expect(screen.getByText('This is another test note.')).toBeInTheDocument()
     expect(screen.getByText('another@example.com')).toBeInTheDocument()
     expect(screen.getByText('05-03-2024 16:07')).toBeInTheDocument()
+  })
+
+  it('does not show an edit link for notes that do not belong to the current user', () => {
+    const notes = [
+      {
+        created_at: '2024-03-05T14:07:00Z',
+        id: 1,
+        text: 'This is a test note.',
+        user: { email: 'test@example.com', id: 2 },
+      },
+    ] as NoteRetrieveOutput[]
+
+    render(<NotesOverview {...defaultProps} notes={notes} />)
+
+    const editLink = screen.queryByRole('link', { name: 'edit-link' })
+
+    expect(editLink).not.toBeInTheDocument()
+  })
+
+  it('shows an edit link for notes that belong to the current user', () => {
+    const notes = [
+      {
+        created_at: '2024-03-05T14:07:00Z',
+        id: 1,
+        text: 'This is a test note.',
+        user: { email: 'test@example.com', id: 1 },
+      },
+    ] as NoteRetrieveOutput[]
+
+    render(<NotesOverview {...defaultProps} notes={notes} />)
+
+    const editLink = screen.getByRole('link', { name: 'edit-link' })
+
+    expect(editLink).toBeInTheDocument()
   })
 
   it('shows a deleted note message when the note text is empty', () => {

--- a/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.test.tsx
@@ -93,4 +93,31 @@ describe('NotesOverview', () => {
 
     expect(screen.getByText('deleted-note')).toBeInTheDocument()
   })
+
+  it('lets a user know when a note was edited', () => {
+    const notes = [
+      {
+        created_at: '2024-03-05T14:07:00Z',
+        id: 1,
+        text: 'This is an edited test note.',
+        updated_at: '2024-03-05T15:07:00Z',
+        user: { email: 'test@example.com', id: 2 },
+      },
+      {
+        created_at: '2024-03-05T16:07:00Z',
+        id: 2,
+        text: 'This note was not edited.',
+        updated_at: '2024-03-05T16:07:00Z',
+        user: { email: 'another@example.com', id: 3 },
+      },
+    ] as NoteRetrieveOutput[]
+
+    render(<NotesOverview {...defaultProps} notes={notes} />)
+
+    const visualOnlyEditedText = screen.getByText('edited', { exact: true, selector: 'span' })
+    const visuallyHiddenEditedText = screen.getByText('visually-hidden-texts.edited')
+
+    expect(visualOnlyEditedText).toBeInTheDocument()
+    expect(visuallyHiddenEditedText).toBeInTheDocument()
+  })
 })

--- a/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.tsx
@@ -68,7 +68,7 @@ export const NotesOverview = ({ meldingId, notes, publicId }: Props) => {
                     <span className="ams-visually-hidden">{t('visually-hidden-texts.by')}</span>
                     <span>{user.email}</span>
                   </Paragraph>
-                  <TipTapMarkdownToHtml markdown={text} />
+                  {text === '' ? <Paragraph>{t('deleted-note')}</Paragraph> : <TipTapMarkdownToHtml markdown={text} />}
                   <StandaloneLink
                     className={styles.link}
                     href={`/melding/${meldingId}/notities/wijzigen/${id}`}

--- a/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.tsx
@@ -3,7 +3,7 @@ import { useTranslations } from 'next-intl'
 
 import type { NoteRetrieveOutput } from '@meldingen/api-client'
 
-import { Grid, Heading, OrderedList, TabNavigation } from '@meldingen/ui'
+import { Grid, Heading, TabNavigation, UnorderedList } from '@meldingen/ui'
 
 import { BackLink } from '../_components/BackLink'
 import { Note } from './_components/Note/Note'
@@ -40,11 +40,11 @@ export const NotesOverview = ({ currentUserId, meldingId, notes, publicId }: Pro
             </TabNavigation.List>
           </TabNavigation>
           {notes.length > 0 && (
-            <OrderedList className={styles.list} markers={false}>
+            <UnorderedList className={styles.list} markers={false}>
               {notes.map((note) => (
                 <Note currentUserId={currentUserId} key={note.id} meldingId={meldingId} note={note} />
               ))}
-            </OrderedList>
+            </UnorderedList>
           )}
           <StandaloneLink
             className="ams-mb-m"

--- a/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.tsx
@@ -11,12 +11,6 @@ import { NextLink } from '~/app/_components'
 
 import styles from './NotesOverview.module.css'
 
-type Props = {
-  meldingId: number
-  notes: NoteRetrieveOutput[]
-  publicId: string
-}
-
 export const formatDateTime = (dateString: string) => {
   const date = new Date(dateString)
 
@@ -35,7 +29,14 @@ export const formatDateTime = (dateString: string) => {
   return `${formattedDate} ${formattedTime}`
 }
 
-export const NotesOverview = ({ meldingId, notes, publicId }: Props) => {
+type Props = {
+  currentUserId: number
+  meldingId: number
+  notes: NoteRetrieveOutput[]
+  publicId: string
+}
+
+export const NotesOverview = ({ currentUserId, meldingId, notes, publicId }: Props) => {
   const t = useTranslations('notes-overview')
 
   return (
@@ -69,13 +70,16 @@ export const NotesOverview = ({ meldingId, notes, publicId }: Props) => {
                     <span>{user.email}</span>
                   </Paragraph>
                   {text === '' ? <Paragraph>{t('deleted-note')}</Paragraph> : <TipTapMarkdownToHtml markdown={text} />}
-                  <StandaloneLink
-                    className={styles.link}
-                    href={`/melding/${meldingId}/notities/wijzigen/${id}`}
-                    linkComponent={NextLink}
-                  >
-                    {t('edit-link')}
-                  </StandaloneLink>
+                  {/* Only show the edit link if the current user is the author of the note */}
+                  {currentUserId === user.id && (
+                    <StandaloneLink
+                      className={styles.link}
+                      href={`/melding/${meldingId}/notities/wijzigen/${id}`}
+                      linkComponent={NextLink}
+                    >
+                      {t('edit-link')}
+                    </StandaloneLink>
+                  )}
                 </OrderedList.Item>
               ))}
             </OrderedList>

--- a/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.tsx
@@ -69,7 +69,11 @@ export const NotesOverview = ({ meldingId, notes, publicId }: Props) => {
                     <span>{user.email}</span>
                   </Paragraph>
                   <TipTapMarkdownToHtml markdown={text} />
-                  <StandaloneLink href={`/melding/${meldingId}/notities/wijzigen/${id}`} linkComponent={NextLink}>
+                  <StandaloneLink
+                    className={styles.link}
+                    href={`/melding/${meldingId}/notities/wijzigen/${id}`}
+                    linkComponent={NextLink}
+                  >
                     {t('edit-link')}
                   </StandaloneLink>
                 </OrderedList.Item>

--- a/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.tsx
@@ -59,29 +59,48 @@ export const NotesOverview = ({ currentUserId, meldingId, notes, publicId }: Pro
           </TabNavigation>
           {notes.length > 0 && (
             <OrderedList className={styles.list} markers={false}>
-              {notes.map(({ created_at, id, text, user }) => (
-                <OrderedList.Item className={styles.note} key={id}>
-                  <Paragraph className={styles.metadata}>
-                    <span className="ams-visually-hidden">{t('visually-hidden-texts.created-at')}</span>
-                    <time className={styles.time} dateTime={created_at}>
-                      {formatDateTime(created_at)}
-                    </time>
-                    <span className="ams-visually-hidden">{t('visually-hidden-texts.by')}</span>
-                    <span>{user.email}</span>
-                  </Paragraph>
-                  {text === '' ? <Paragraph>{t('deleted-note')}</Paragraph> : <TipTapMarkdownToHtml markdown={text} />}
-                  {/* Only show the edit link if the current user is the author of the note */}
-                  {currentUserId === user.id && (
-                    <StandaloneLink
-                      className={styles.link}
-                      href={`/melding/${meldingId}/notities/wijzigen/${id}`}
-                      linkComponent={NextLink}
-                    >
-                      {t('edit-link')}
-                    </StandaloneLink>
-                  )}
-                </OrderedList.Item>
-              ))}
+              {notes.map(({ created_at, id, text, updated_at, user }) => {
+                const wasEdited = new Date(updated_at) > new Date(created_at)
+
+                return (
+                  <OrderedList.Item className={styles.note} key={id}>
+                    <Paragraph className={styles.metadata}>
+                      <span className="ams-visually-hidden">{t('visually-hidden-texts.created-at')}</span>
+                      <span>
+                        <time className={styles.time} dateTime={created_at}>
+                          {formatDateTime(created_at)}
+                        </time>
+                        {wasEdited && (
+                          <>
+                            {' '}
+                            <span className={styles.editedVisualText} hidden>
+                              {t('edited')}
+                            </span>
+                          </>
+                        )}
+                      </span>
+                      <span className="ams-visually-hidden">{t('visually-hidden-texts.by')}</span>
+                      <span>{user.email}</span>
+                      {wasEdited && <span className="ams-visually-hidden">{t('visually-hidden-texts.edited')}</span>}
+                    </Paragraph>
+                    {text === '' ? (
+                      <Paragraph>{t('deleted-note')}</Paragraph>
+                    ) : (
+                      <TipTapMarkdownToHtml markdown={text} />
+                    )}
+                    {/* Only show the edit link if the current user is the author of the note */}
+                    {currentUserId === user.id && (
+                      <StandaloneLink
+                        className={styles.link}
+                        href={`/melding/${meldingId}/notities/wijzigen/${id}`}
+                        linkComponent={NextLink}
+                      >
+                        {t('edit-link')}
+                      </StandaloneLink>
+                    )}
+                  </OrderedList.Item>
+                )
+              })}
             </OrderedList>
           )}
           <StandaloneLink

--- a/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.tsx
@@ -69,6 +69,9 @@ export const NotesOverview = ({ meldingId, notes, publicId }: Props) => {
                     <span>{user.email}</span>
                   </Paragraph>
                   <TipTapMarkdownToHtml markdown={text} />
+                  <StandaloneLink href={`/melding/${meldingId}/notities/wijzigen/${id}`} linkComponent={NextLink}>
+                    {t('edit-link')}
+                  </StandaloneLink>
                 </OrderedList.Item>
               ))}
             </OrderedList>

--- a/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/NotesOverview.tsx
@@ -3,31 +3,13 @@ import { useTranslations } from 'next-intl'
 
 import type { NoteRetrieveOutput } from '@meldingen/api-client'
 
-import { Grid, Heading, OrderedList, Paragraph, TabNavigation } from '@meldingen/ui'
+import { Grid, Heading, OrderedList, TabNavigation } from '@meldingen/ui'
 
 import { BackLink } from '../_components/BackLink'
-import { TipTapMarkdownToHtml } from './_components/TipTapMarkdownToHtml'
+import { Note } from './_components/Note/Note'
 import { NextLink } from '~/app/_components'
 
 import styles from './NotesOverview.module.css'
-
-export const formatDateTime = (dateString: string) => {
-  const date = new Date(dateString)
-
-  const formattedDate = date.toLocaleDateString('nl-NL', {
-    day: '2-digit',
-    month: '2-digit',
-    timeZone: 'Europe/Amsterdam',
-    year: 'numeric',
-  })
-  const formattedTime = date.toLocaleTimeString('nl-NL', {
-    hour: 'numeric',
-    minute: 'numeric',
-    timeZone: 'Europe/Amsterdam',
-  })
-
-  return `${formattedDate} ${formattedTime}`
-}
 
 type Props = {
   currentUserId: number
@@ -59,48 +41,9 @@ export const NotesOverview = ({ currentUserId, meldingId, notes, publicId }: Pro
           </TabNavigation>
           {notes.length > 0 && (
             <OrderedList className={styles.list} markers={false}>
-              {notes.map(({ created_at, id, text, updated_at, user }) => {
-                const wasEdited = new Date(updated_at) > new Date(created_at)
-
-                return (
-                  <OrderedList.Item className={styles.note} key={id}>
-                    <Paragraph className={styles.metadata}>
-                      <span className="ams-visually-hidden">{t('visually-hidden-texts.created-at')}</span>
-                      <span>
-                        <time className={styles.time} dateTime={created_at}>
-                          {formatDateTime(created_at)}
-                        </time>
-                        {wasEdited && (
-                          <>
-                            {' '}
-                            <span className={styles.editedVisualText} hidden>
-                              {t('edited')}
-                            </span>
-                          </>
-                        )}
-                      </span>
-                      <span className="ams-visually-hidden">{t('visually-hidden-texts.by')}</span>
-                      <span>{user.email}</span>
-                      {wasEdited && <span className="ams-visually-hidden">{t('visually-hidden-texts.edited')}</span>}
-                    </Paragraph>
-                    {text === '' ? (
-                      <Paragraph>{t('deleted-note')}</Paragraph>
-                    ) : (
-                      <TipTapMarkdownToHtml markdown={text} />
-                    )}
-                    {/* Only show the edit link if the current user is the author of the note */}
-                    {currentUserId === user.id && (
-                      <StandaloneLink
-                        className={styles.link}
-                        href={`/melding/${meldingId}/notities/wijzigen/${id}`}
-                        linkComponent={NextLink}
-                      >
-                        {t('edit-link')}
-                      </StandaloneLink>
-                    )}
-                  </OrderedList.Item>
-                )
-              })}
+              {notes.map((note) => (
+                <Note currentUserId={currentUserId} key={note.id} meldingId={meldingId} note={note} />
+              ))}
             </OrderedList>
           )}
           <StandaloneLink

--- a/apps/back-office/src/app/melding/[meldingId]/notities/_components/Note/Note.module.css
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/_components/Note/Note.module.css
@@ -1,0 +1,27 @@
+.item {
+  background-color: var(--ams-color-background);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ams-space-s);
+  padding-block: var(--ams-space-m);
+  padding-inline: var(--ams-space-m);
+}
+
+.metadata {
+  display: flex;
+  flex-direction: column;
+}
+
+.time {
+  font-weight: var(--ams-typography-body-text-bold-font-weight);
+}
+
+.editedVisualText {
+  color: var(--ams-color-text-secondary);
+  display: inline-block;
+  font-weight: var(--ams-typography-body-text-bold-font-weight);
+}
+
+.link {
+  inline-size: fit-content;
+}

--- a/apps/back-office/src/app/melding/[meldingId]/notities/_components/Note/Note.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/_components/Note/Note.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react'
+
+import type { NoteRetrieveOutput } from '@meldingen/api-client'
+
+import { formatDateTime, Note } from './Note'
+
+describe('formatDateTime', () => {
+  it('formats a date string correctly', () => {
+    expect(formatDateTime('2024-03-05T08:09:00Z')).toBe('05-03-2024 09:09')
+  })
+})
+
+const mockNote = {
+  created_at: '2024-03-05T08:09:00Z',
+  id: 1,
+  text: 'This is a test note.',
+  updated_at: '2024-03-05T08:09:00Z',
+  user: {
+    email: 'test@example.com',
+  },
+} as NoteRetrieveOutput
+
+describe('Note', () => {
+  it('renders the note text and user email', () => {
+    render(<Note currentUserId={1} meldingId={123} note={mockNote} />)
+
+    expect(screen.getByText('This is a test note.')).toBeInTheDocument()
+    expect(screen.getByText('test@example.com')).toBeInTheDocument()
+    expect(screen.getByText('05-03-2024 09:09')).toBeInTheDocument()
+  })
+
+  it('does not show an edit link for a note that does not belong to the current user', () => {
+    const someonesNote = {
+      ...mockNote,
+      user: { email: 'test@example.com', id: 2 },
+    } as NoteRetrieveOutput
+
+    render(<Note currentUserId={1} meldingId={123} note={someonesNote} />)
+
+    const editLink = screen.queryByRole('link', { name: 'edit-link' })
+
+    expect(editLink).not.toBeInTheDocument()
+  })
+
+  it('shows an edit link for notes that belong to the current user', () => {
+    const myNote = {
+      ...mockNote,
+      user: { email: 'test@example.com', id: 1 },
+    } as NoteRetrieveOutput
+
+    render(<Note currentUserId={1} meldingId={123} note={myNote} />)
+
+    const editLink = screen.getByRole('link', { name: 'edit-link' })
+
+    expect(editLink).toBeInTheDocument()
+  })
+
+  it('shows a deleted note message when the note text is empty', () => {
+    const emptyNote = { ...mockNote, text: '' }
+
+    render(<Note currentUserId={1} meldingId={123} note={emptyNote} />)
+
+    expect(screen.getByText('deleted-note')).toBeInTheDocument()
+  })
+
+  it('lets a user know when a note was edited', () => {
+    const editedNote = {
+      ...mockNote,
+      updated_at: '2024-03-05T09:09:00Z',
+    } as NoteRetrieveOutput
+
+    render(<Note currentUserId={1} meldingId={123} note={editedNote} />)
+
+    const visualOnlyEditedText = screen.getByText('edited', { exact: true, selector: 'span' })
+    const visuallyHiddenEditedText = screen.getByText('visually-hidden-texts.edited')
+
+    expect(visualOnlyEditedText).toBeInTheDocument()
+    expect(visuallyHiddenEditedText).toBeInTheDocument()
+  })
+})

--- a/apps/back-office/src/app/melding/[meldingId]/notities/_components/Note/Note.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/_components/Note/Note.test.tsx
@@ -53,6 +53,7 @@ describe('Note', () => {
     const editLink = screen.getByRole('link', { name: 'edit-link' })
 
     expect(editLink).toBeInTheDocument()
+    expect(editLink).toHaveAttribute('href', '/melding/123/notities/wijzigen/1')
   })
 
   it('shows a deleted note message when the note text is empty', () => {

--- a/apps/back-office/src/app/melding/[meldingId]/notities/_components/Note/Note.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/_components/Note/Note.test.tsx
@@ -21,7 +21,7 @@ const mockNote = {
 } as NoteRetrieveOutput
 
 describe('Note', () => {
-  it('renders the note text and user email', () => {
+  it('renders the note', () => {
     render(<Note currentUserId={1} meldingId={123} note={mockNote} />)
 
     expect(screen.getByText('This is a test note.')).toBeInTheDocument()
@@ -30,12 +30,12 @@ describe('Note', () => {
   })
 
   it('does not show an edit link for a note that does not belong to the current user', () => {
-    const someonesNote = {
+    const noteFromSomeoneElse = {
       ...mockNote,
       user: { email: 'test@example.com', id: 2 },
     } as NoteRetrieveOutput
 
-    render(<Note currentUserId={1} meldingId={123} note={someonesNote} />)
+    render(<Note currentUserId={1} meldingId={123} note={noteFromSomeoneElse} />)
 
     const editLink = screen.queryByRole('link', { name: 'edit-link' })
 

--- a/apps/back-office/src/app/melding/[meldingId]/notities/_components/Note/Note.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/_components/Note/Note.tsx
@@ -1,0 +1,78 @@
+import { StandaloneLink } from '@amsterdam/design-system-react/dist/StandaloneLink'
+import { useTranslations } from 'next-intl'
+
+import type { NoteRetrieveOutput } from '@meldingen/api-client'
+
+import { OrderedList, Paragraph } from '@meldingen/ui'
+
+import { TipTapMarkdownToHtml } from '../TipTapMarkdownToHtml'
+import { NextLink } from '~/app/_components'
+
+import styles from './Note.module.css'
+
+export const formatDateTime = (dateString: string) => {
+  const date = new Date(dateString)
+
+  const formattedDate = date.toLocaleDateString('nl-NL', {
+    day: '2-digit',
+    month: '2-digit',
+    timeZone: 'Europe/Amsterdam',
+    year: 'numeric',
+  })
+  const formattedTime = date.toLocaleTimeString('nl-NL', {
+    hour: 'numeric',
+    minute: 'numeric',
+    timeZone: 'Europe/Amsterdam',
+  })
+
+  return `${formattedDate} ${formattedTime}`
+}
+
+type Props = {
+  currentUserId: number
+  meldingId: number
+  note: NoteRetrieveOutput
+}
+
+export const Note = ({ currentUserId, meldingId, note }: Props) => {
+  const t = useTranslations('notes-overview')
+
+  const { created_at, id, text, updated_at, user } = note
+
+  const wasEdited = new Date(updated_at) > new Date(created_at)
+
+  return (
+    <OrderedList.Item className={styles.item} key={id}>
+      <Paragraph className={styles.metadata}>
+        <span className="ams-visually-hidden">{t('visually-hidden-texts.created-at')}</span>
+        <span>
+          <time className={styles.time} dateTime={created_at}>
+            {formatDateTime(created_at)}
+          </time>
+          {wasEdited && (
+            <>
+              {' '}
+              <span className={styles.editedVisualText} hidden>
+                {t('edited')}
+              </span>
+            </>
+          )}
+        </span>
+        <span className="ams-visually-hidden">{t('visually-hidden-texts.by')}</span>
+        <span>{user.email}</span>
+        {wasEdited && <span className="ams-visually-hidden">{t('visually-hidden-texts.edited')}</span>}
+      </Paragraph>
+      {text === '' ? <Paragraph>{t('deleted-note')}</Paragraph> : <TipTapMarkdownToHtml markdown={text} />}
+      {/* Only show the edit link if the current user is the author of the note */}
+      {currentUserId === user.id && (
+        <StandaloneLink
+          className={styles.link}
+          href={`/melding/${meldingId}/notities/wijzigen/${id}`}
+          linkComponent={NextLink}
+        >
+          {t('edit-link')}
+        </StandaloneLink>
+      )}
+    </OrderedList.Item>
+  )
+}

--- a/apps/back-office/src/app/melding/[meldingId]/notities/_components/Note/Note.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/_components/Note/Note.tsx
@@ -42,7 +42,7 @@ export const Note = ({ currentUserId, meldingId, note }: Props) => {
   const wasEdited = new Date(updated_at) > new Date(created_at)
 
   return (
-    <UnorderedList.Item className={styles.item} key={id}>
+    <UnorderedList.Item className={styles.item}>
       <Paragraph className={styles.metadata}>
         <span className="ams-visually-hidden">{t('visually-hidden-texts.created-at')}</span>
         <span>

--- a/apps/back-office/src/app/melding/[meldingId]/notities/_components/Note/Note.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/_components/Note/Note.tsx
@@ -3,7 +3,7 @@ import { useTranslations } from 'next-intl'
 
 import type { NoteRetrieveOutput } from '@meldingen/api-client'
 
-import { OrderedList, Paragraph } from '@meldingen/ui'
+import { Paragraph, UnorderedList } from '@meldingen/ui'
 
 import { TipTapMarkdownToHtml } from '../TipTapMarkdownToHtml'
 import { NextLink } from '~/app/_components'
@@ -42,7 +42,7 @@ export const Note = ({ currentUserId, meldingId, note }: Props) => {
   const wasEdited = new Date(updated_at) > new Date(created_at)
 
   return (
-    <OrderedList.Item className={styles.item} key={id}>
+    <UnorderedList.Item className={styles.item} key={id}>
       <Paragraph className={styles.metadata}>
         <span className="ams-visually-hidden">{t('visually-hidden-texts.created-at')}</span>
         <span>
@@ -73,6 +73,6 @@ export const Note = ({ currentUserId, meldingId, note }: Props) => {
           {t('edit-link')}
         </StandaloneLink>
       )}
-    </OrderedList.Item>
+    </UnorderedList.Item>
   )
 }

--- a/apps/back-office/src/app/melding/[meldingId]/notities/page.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/page.test.tsx
@@ -55,6 +55,9 @@ describe('Page', () => {
 
     render(result)
 
-    expect(NotesOverview).toHaveBeenCalledWith({ meldingId: 123, notes: [], publicId: melding.public_id }, undefined)
+    expect(NotesOverview).toHaveBeenCalledWith(
+      { currentUserId: 1, meldingId: 123, notes: [], publicId: melding.public_id },
+      undefined,
+    )
   })
 })

--- a/apps/back-office/src/app/melding/[meldingId]/notities/page.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/page.tsx
@@ -1,7 +1,7 @@
 import { getTranslations } from 'next-intl/server'
 
 import { NotesOverview } from './NotesOverview'
-import { getMeldingByMeldingId, getMeldingByMeldingIdNote } from '~/app/_api-client/proxy'
+import { getMeldingByMeldingId, getMeldingByMeldingIdNote, getUserMe } from '~/app/_api-client/proxy'
 
 export const generateMetadata = async ({ params }: { params: Promise<{ meldingId: number }> }) => {
   const { meldingId } = await params
@@ -29,5 +29,9 @@ export default async ({ params }: { params: Promise<{ meldingId: number }> }) =>
 
   if (notesError) throw new Error('Failed to fetch notes data.')
 
-  return <NotesOverview meldingId={meldingId} notes={notes} publicId={data.public_id} />
+  const { data: currentUser, error: currentUserError } = await getUserMe()
+
+  if (currentUserError) throw new Error('Failed to fetch current user data.')
+
+  return <NotesOverview currentUserId={currentUser.id} meldingId={meldingId} notes={notes} publicId={data.public_id} />
 }

--- a/apps/back-office/src/app/melding/[meldingId]/notities/page.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/page.tsx
@@ -18,19 +18,18 @@ export const generateMetadata = async ({ params }: { params: Promise<{ meldingId
 export default async ({ params }: { params: Promise<{ meldingId: number }> }) => {
   const { meldingId } = await params
 
-  const { data, error } = await getMeldingByMeldingId({ path: { melding_id: meldingId } })
+  const [{ data, error }, { data: notes, error: notesError }, { data: currentUser, error: currentUserError }] =
+    await Promise.all([
+      getMeldingByMeldingId({ path: { melding_id: meldingId } }),
+      getMeldingByMeldingIdNote({
+        path: { melding_id: meldingId },
+        query: { sort: '["created_at","DESC"]' },
+      }),
+      getUserMe(),
+    ])
 
   if (error) throw new Error('Failed to fetch melding data.')
-
-  const { data: notes, error: notesError } = await getMeldingByMeldingIdNote({
-    path: { melding_id: meldingId },
-    query: { sort: '["created_at","DESC"]' },
-  })
-
   if (notesError) throw new Error('Failed to fetch notes data.')
-
-  const { data: currentUser, error: currentUserError } = await getUserMe()
-
   if (currentUserError) throw new Error('Failed to fetch current user data.')
 
   return <NotesOverview currentUserId={currentUser.id} meldingId={meldingId} notes={notes} publicId={data.public_id} />

--- a/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/UpdateNote.module.css
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/UpdateNote.module.css
@@ -1,0 +1,6 @@
+.whiteField {
+  background-color: var(--ams-color-background);
+  margin-block-end: var(--ams-space-m);
+  padding-block: var(--ams-space-l);
+  padding-inline: var(--ams-space-l);
+}

--- a/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/UpdateNote.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/UpdateNote.test.tsx
@@ -1,0 +1,104 @@
+import type { Mock } from 'vitest'
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useActionState } from 'react'
+
+import type { NoteRetrieveOutput } from '@meldingen/api-client'
+
+import { UpdateNote } from './UpdateNote'
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...(typeof actual === 'object' ? actual : {}),
+    useActionState: vi.fn().mockReturnValue([{}, vi.fn()]),
+  }
+})
+
+const defaultProps = {
+  meldingId: 123,
+  note: {
+    id: 456,
+    text: 'This is a note.',
+  } as NoteRetrieveOutput,
+  noteId: 456,
+}
+
+describe('UpdateNote', () => {
+  it('renders the back link', () => {
+    render(<UpdateNote {...defaultProps} />)
+
+    const backLink = screen.getByRole('link', { name: 'back-link' })
+    expect(backLink).toBeInTheDocument()
+    expect(backLink).toHaveAttribute('href', '/melding/123')
+  })
+
+  it('renders the correct title', () => {
+    render(<UpdateNote {...defaultProps} />)
+
+    expect(screen.getByRole('heading', { name: 'title' })).toBeInTheDocument()
+  })
+
+  it('renders the rich text editor', async () => {
+    render(<UpdateNote {...defaultProps} />)
+
+    expect(await screen.findByRole('toolbar')).toBeInTheDocument()
+
+    expect(screen.getByRole('textbox', { name: 'label' })).toBeInTheDocument()
+  })
+
+  it('renders the cancel link', () => {
+    render(<UpdateNote {...defaultProps} />)
+
+    const cancelLink = screen.getByRole('link', { name: 'cancel-link' })
+    expect(cancelLink).toBeInTheDocument()
+    expect(cancelLink).toHaveAttribute('href', '/melding/123')
+  })
+
+  it('displays a system error alert when there is one', () => {
+    ;(useActionState as Mock).mockReturnValueOnce([{ systemError: { detail: 'Something went wrong' } }, vi.fn()])
+
+    render(<UpdateNote {...defaultProps} />)
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+
+  it('displays an invalid form alert when there are validation errors', async () => {
+    const formData = new FormData()
+    formData.append('updateNote', 'Some note text')
+    ;(useActionState as Mock).mockReturnValueOnce([
+      { formData, validationErrors: [{ key: 'updateNote', message: 'Error message' }] },
+      vi.fn(),
+    ])
+
+    render(<UpdateNote {...defaultProps} />)
+
+    expect(await screen.findByRole('toolbar')).toBeInTheDocument()
+
+    expect(screen.getByRole('link', { name: 'Error message' })).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: 'label' })).toHaveTextContent('Some note text')
+  })
+
+  it('renders a default value in the Rich Text Editor when provided', async () => {
+    render(<UpdateNote {...defaultProps} />)
+
+    expect(await screen.findByRole('toolbar')).toBeInTheDocument()
+
+    expect(screen.getByRole('textbox', { name: 'label' })).toHaveTextContent('This is a note.')
+  })
+
+  it('submits the form when the submit button is clicked', async () => {
+    const user = userEvent.setup()
+
+    const mockFormAction = vi.fn()
+    ;(useActionState as Mock).mockReturnValueOnce([{}, mockFormAction])
+
+    render(<UpdateNote {...defaultProps} />)
+
+    const submitButton = screen.getByRole('button', { name: 'submit-button' })
+    await user.click(submitButton)
+
+    expect(mockFormAction).toHaveBeenCalled()
+  })
+})

--- a/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/UpdateNote.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/UpdateNote.test.tsx
@@ -22,7 +22,6 @@ const defaultProps = {
     id: 456,
     text: 'This is a note.',
   } as NoteRetrieveOutput,
-  noteId: 456,
 }
 
 describe('UpdateNote', () => {

--- a/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/UpdateNote.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/UpdateNote.tsx
@@ -54,7 +54,7 @@ export const UpdateNote = ({ meldingId, note, noteId }: Props) => {
     }
   }, [systemError])
 
-  const defaultValue = formData?.get('updateNote')?.toString() ?? note?.text ?? ''
+  const defaultValue = formData?.get('updateNote')?.toString() ?? note.text
   const errorMessage = validationErrors?.find((error) => error.key === 'updateNote')?.message
 
   return (

--- a/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/UpdateNote.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/UpdateNote.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { ActionGroup, Button, ErrorMessage, Field, Grid, Heading, Label } from '@amsterdam/design-system-react'
+import { useTranslations } from 'next-intl'
+import Form from 'next/form'
+import { useActionState, useEffect, useRef } from 'react'
+
+import type { NoteRetrieveOutput } from '@meldingen/api-client'
+
+import { getAriaDescribedBy } from '@meldingen/form-renderer'
+
+import type { FormState } from '~/types'
+
+import { BackLink } from '../../../_components/BackLink'
+import { CancelLink } from '../../../_components/CancelLink'
+import { postUpdateNoteForm } from './actions'
+import { InvalidFormAlert, RichTextEditor, SystemErrorAlert } from '~/app/_components'
+
+import styles from './UpdateNote.module.css'
+
+const initialState: FormState = {}
+
+type Props = {
+  meldingId: number
+  note: NoteRetrieveOutput
+  noteId: number
+}
+
+export const UpdateNote = ({ meldingId, note, noteId }: Props) => {
+  const invalidFormAlertRef = useRef<HTMLDivElement>(null)
+  const systemErrorAlertRef = useRef<HTMLDivElement>(null)
+
+  const action = postUpdateNoteForm.bind(null, { meldingId, noteId })
+
+  const [{ formData, systemError, validationErrors }, formAction] = useActionState(action, initialState)
+
+  const t = useTranslations('update-note')
+
+  // Set focus on InvalidFormAlert when there are validation errors
+  // and on SystemErrorAlert when there is a system error
+  useEffect(() => {
+    if (validationErrors && invalidFormAlertRef.current) {
+      invalidFormAlertRef.current.focus()
+    } else if (systemError && systemErrorAlertRef.current) {
+      systemErrorAlertRef.current.focus()
+    }
+  }, [validationErrors, systemError])
+
+  useEffect(() => {
+    if (systemError) {
+      // TODO: Log the error to an error reporting service
+      // eslint-disable-next-line no-console
+      console.error(systemError)
+    }
+  }, [systemError])
+
+  const defaultValue = formData?.get('updateNote')?.toString() ?? note?.text ?? ''
+  const errorMessage = validationErrors?.find((error) => error.key === 'updateNote')?.message
+
+  return (
+    <div className="ams-page__area--body">
+      <BackLink href={`/melding/${meldingId}`}>{t('back-link')}</BackLink>
+      <Grid as="main" gapVertical="large">
+        <Grid.Cell appearance="transparent" span={{ narrow: 4, medium: 6, wide: 6 }}>
+          {Boolean(systemError) && <SystemErrorAlert ref={systemErrorAlertRef} />}
+          {validationErrors && (
+            <InvalidFormAlert
+              ref={invalidFormAlertRef}
+              title={t('invalid-form-alert-title')}
+              validationErrors={validationErrors}
+            />
+          )}
+          <Heading className="ams-mb-m" level={1}>
+            {t('title')}
+          </Heading>
+          <Form action={formAction} noValidate>
+            <div className={styles.whiteField}>
+              <Field invalid={Boolean(errorMessage)}>
+                <Label id="updateNote-label">{t('label')}</Label>
+                {errorMessage && <ErrorMessage id="updateNote-error">{errorMessage}</ErrorMessage>}
+                <RichTextEditor
+                  aria-describedby={getAriaDescribedBy('updateNote', undefined, errorMessage)}
+                  aria-labelledby="updateNote-label"
+                  aria-required="true"
+                  defaultValue={defaultValue}
+                  id="updateNote"
+                  invalid={Boolean(errorMessage)}
+                  name="updateNote"
+                />
+              </Field>
+            </div>
+            <ActionGroup>
+              <Button type="submit">{t('submit-button')}</Button>
+              <CancelLink href={`/melding/${meldingId}`}>{t('cancel-link')}</CancelLink>
+            </ActionGroup>
+          </Form>
+        </Grid.Cell>
+      </Grid>
+    </div>
+  )
+}

--- a/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/UpdateNote.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/UpdateNote.tsx
@@ -81,7 +81,6 @@ export const UpdateNote = ({ meldingId, note, noteId }: Props) => {
                 <RichTextEditor
                   aria-describedby={getAriaDescribedBy('updateNote', undefined, errorMessage)}
                   aria-labelledby="updateNote-label"
-                  aria-required="true"
                   defaultValue={defaultValue}
                   id="updateNote"
                   invalid={Boolean(errorMessage)}

--- a/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/UpdateNote.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/UpdateNote.tsx
@@ -23,14 +23,13 @@ const initialState: FormState = {}
 type Props = {
   meldingId: number
   note: NoteRetrieveOutput
-  noteId: number
 }
 
-export const UpdateNote = ({ meldingId, note, noteId }: Props) => {
+export const UpdateNote = ({ meldingId, note }: Props) => {
   const invalidFormAlertRef = useRef<HTMLDivElement>(null)
   const systemErrorAlertRef = useRef<HTMLDivElement>(null)
 
-  const action = postUpdateNoteForm.bind(null, { meldingId, noteId })
+  const action = postUpdateNoteForm.bind(null, { meldingId, noteId: note.id })
 
   const [{ formData, systemError, validationErrors }, formAction] = useActionState(action, initialState)
 

--- a/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/UpdateNote.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/UpdateNote.tsx
@@ -76,7 +76,9 @@ export const UpdateNote = ({ meldingId, note, noteId }: Props) => {
           <Form action={formAction} noValidate>
             <div className={styles.whiteField}>
               <Field invalid={Boolean(errorMessage)}>
-                <Label id="updateNote-label">{t('label')}</Label>
+                <Label className="ams-mb-s" id="updateNote-label">
+                  {t('label')}
+                </Label>
                 {errorMessage && <ErrorMessage id="updateNote-error">{errorMessage}</ErrorMessage>}
                 <RichTextEditor
                   aria-describedby={getAriaDescribedBy('updateNote', undefined, errorMessage)}

--- a/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/actions.test.ts
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/actions.test.ts
@@ -46,7 +46,7 @@ describe('postUpdateNoteForm', () => {
       formData,
       systemError: { detail: 'Error message' },
     })
-    expect(redirect).not.toHaveBeenCalled()
+    expect(redirect).not.toHaveBeenCalledWith('/melding/123')
   })
 
   it('redirects on success', async () => {

--- a/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/actions.test.ts
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/actions.test.ts
@@ -46,7 +46,7 @@ describe('postUpdateNoteForm', () => {
       formData,
       systemError: { detail: 'Error message' },
     })
-    expect(redirect).not.toHaveBeenCalledWith('/melding/123')
+    expect(redirect).not.toHaveBeenCalled()
   })
 
   it('redirects on success', async () => {

--- a/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/actions.test.ts
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/actions.test.ts
@@ -1,0 +1,69 @@
+import { http, HttpResponse } from 'msw'
+import { redirect } from 'next/navigation'
+
+import { postUpdateNoteForm } from './actions'
+import { MAX_NOTE_LENGTH } from '~/constants'
+import { ENDPOINTS } from '~/mocks/endpoints'
+import { server } from '~/mocks/node'
+
+const defaultArgs = { meldingId: 123, noteId: 456 }
+
+// RichTextEditor submits the ProseMirror doc as JSON, so tests build that same shape here
+// instead of appending plain markdown/text.
+const noteDoc = (text: string) =>
+  JSON.stringify({
+    content: [{ content: text ? [{ text, type: 'text' }] : [], type: 'paragraph' }],
+    type: 'doc',
+  })
+
+describe('postUpdateNoteForm', () => {
+  it('returns a validation error when updateNote exceeds the maximum length', async () => {
+    const formData = new FormData()
+    formData.append('updateNote', noteDoc('a'.repeat(MAX_NOTE_LENGTH + 1)))
+
+    const result = await postUpdateNoteForm(defaultArgs, null, formData)
+
+    expect(result).toEqual({
+      formData,
+      validationErrors: [{ key: 'updateNote', message: 'errors.maxLength' }],
+    })
+    expect(redirect).not.toHaveBeenCalled()
+  })
+
+  it('returns a system error when the API returns an error', async () => {
+    server.use(
+      http.patch(ENDPOINTS.PATCH_MELDING_BY_MELDING_ID_NOTE_BY_NOTE_ID, () =>
+        HttpResponse.json({ detail: 'Error message' }, { status: 500 }),
+      ),
+    )
+
+    const formData = new FormData()
+    formData.append('updateNote', noteDoc('Some note text'))
+
+    const result = await postUpdateNoteForm(defaultArgs, null, formData)
+
+    expect(result).toEqual({
+      formData,
+      systemError: { detail: 'Error message' },
+    })
+    expect(redirect).not.toHaveBeenCalledWith('/melding/123')
+  })
+
+  it('redirects on success', async () => {
+    const formData = new FormData()
+    formData.append('updateNote', noteDoc('Some note text'))
+
+    await postUpdateNoteForm(defaultArgs, null, formData)
+
+    expect(redirect).toHaveBeenCalledWith('/melding/123/notities')
+  })
+
+  it('accepts a note at exactly the maximum length', async () => {
+    const formData = new FormData()
+    formData.append('updateNote', noteDoc('a'.repeat(MAX_NOTE_LENGTH)))
+
+    await postUpdateNoteForm(defaultArgs, null, formData)
+
+    expect(redirect).toHaveBeenCalledWith('/melding/123/notities')
+  })
+})

--- a/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/actions.test.ts
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/actions.test.ts
@@ -66,4 +66,35 @@ describe('postUpdateNoteForm', () => {
 
     expect(redirect).toHaveBeenCalledWith('/melding/123/notities')
   })
+
+  it('posts an empty string when the editor only contains whitespace, even when it has markup', async () => {
+    let requestBody: { text?: string } | undefined
+
+    server.use(
+      http.patch(ENDPOINTS.PATCH_MELDING_BY_MELDING_ID_NOTE_BY_NOTE_ID, async ({ request }) => {
+        requestBody = (await request.json()) as { text?: string }
+        return HttpResponse.json({}, { status: 200 })
+      }),
+    )
+
+    const markedUpWhitespace = JSON.stringify({
+      content: [
+        {
+          content: [
+            { marks: [{ type: 'bold' }, { type: 'italic' }, { type: 'underline' }], text: '   ', type: 'text' },
+          ],
+          type: 'paragraph',
+        },
+      ],
+      type: 'doc',
+    })
+
+    const formData = new FormData()
+    formData.append('updateNote', markedUpWhitespace)
+
+    await postUpdateNoteForm(defaultArgs, null, formData)
+
+    expect(requestBody).toEqual({ text: '' })
+    expect(redirect).toHaveBeenCalledWith('/melding/123/notities')
+  })
 })

--- a/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/actions.ts
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/actions.ts
@@ -1,0 +1,41 @@
+'use server'
+
+import { getTranslations } from 'next-intl/server'
+import { redirect } from 'next/navigation'
+
+import { patchMeldingByMeldingIdNoteByNoteId } from '~/app/_api-client/proxy'
+import { parseNoteDocument } from '~/app/_utils/parseNoteDocument'
+import { MAX_NOTE_LENGTH } from '~/constants'
+
+type Args = {
+  meldingId: number
+  noteId: number
+}
+
+export const postUpdateNoteForm = async ({ meldingId, noteId }: Args, _: unknown, formData: FormData) => {
+  const t = await getTranslations('update-note')
+
+  const formDataObj = Object.fromEntries(formData)
+
+  const { characterCount, markdown } = parseNoteDocument(formDataObj.updateNote)
+
+  // Replace the submitted JSON with the derived markdown, so RichTextEditor can reload it as
+  // its `defaultValue` (via contentType: 'markdown') if the form is redisplayed after an error.
+  formData.set('updateNote', markdown)
+
+  if (characterCount > MAX_NOTE_LENGTH) {
+    return {
+      formData,
+      validationErrors: [{ key: 'updateNote', message: t('errors.maxLength', { max: MAX_NOTE_LENGTH }) }],
+    }
+  }
+
+  const { error } = await patchMeldingByMeldingIdNoteByNoteId({
+    body: { text: markdown },
+    path: { melding_id: meldingId, note_id: noteId },
+  })
+
+  if (error) return { formData, systemError: error }
+
+  return redirect(`/melding/${meldingId}/notities`)
+}

--- a/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/actions.ts
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/actions.ts
@@ -17,7 +17,7 @@ export const postUpdateNoteForm = async ({ meldingId, noteId }: Args, _: unknown
 
   const formDataObj = Object.fromEntries(formData)
 
-  const { characterCount, markdown } = parseNoteDocument(formDataObj.updateNote)
+  const { characterCount, isEmpty, markdown } = parseNoteDocument(formDataObj.updateNote)
 
   // Replace the submitted JSON with the derived markdown, so RichTextEditor can reload it as
   // its `defaultValue` (via contentType: 'markdown') if the form is redisplayed after an error.
@@ -31,7 +31,7 @@ export const postUpdateNoteForm = async ({ meldingId, noteId }: Args, _: unknown
   }
 
   const { error } = await patchMeldingByMeldingIdNoteByNoteId({
-    body: { text: markdown },
+    body: { text: isEmpty ? '' : markdown },
     path: { melding_id: meldingId, note_id: noteId },
   })
 

--- a/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/page.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/page.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { vi } from 'vitest'
+
+import Page, { generateMetadata } from './page'
+import { ENDPOINTS } from '~/mocks/endpoints'
+import { server } from '~/mocks/node'
+
+vi.mock('./UpdateNote', () => ({
+  UpdateNote: vi.fn(() => <div>UpdateNote Component</div>),
+}))
+
+describe('generateMetadata', () => {
+  it('returns the correct metadata title', async () => {
+    const metadata = await generateMetadata()
+
+    expect(metadata).toEqual({ title: 'metadata.title' })
+  })
+})
+
+describe('Page', () => {
+  it('renders', async () => {
+    const params = Promise.resolve({ meldingId: 123, noteId: 456 })
+
+    const result = await Page({ params })
+
+    render(result)
+
+    expect(screen.getByText('UpdateNote Component')).toBeInTheDocument()
+  })
+
+  it('throws an error when fetching note fails', async () => {
+    server.use(
+      http.get(ENDPOINTS.GET_MELDING_BY_MELDING_ID_NOTE_BY_NOTE_ID, () =>
+        HttpResponse.json({ detail: 'Error message' }, { status: 500 }),
+      ),
+    )
+
+    const params = Promise.resolve({ meldingId: 123, noteId: 456 })
+
+    await expect(Page({ params })).rejects.toThrow('Failed to fetch note.')
+  })
+})

--- a/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/page.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/page.tsx
@@ -22,5 +22,5 @@ export default async ({ params }: Params) => {
 
   if (error) throw new Error('Failed to fetch note.')
 
-  return <UpdateNote meldingId={meldingId} note={data} noteId={noteId} />
+  return <UpdateNote meldingId={meldingId} note={data} />
 }

--- a/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/page.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/wijzigen/[noteId]/page.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from 'next'
+
+import { getTranslations } from 'next-intl/server'
+
+import { UpdateNote } from './UpdateNote'
+import { getMeldingByMeldingIdNoteByNoteId } from '~/app/_api-client/proxy'
+
+export const generateMetadata = async (): Promise<Metadata> => {
+  const t = await getTranslations('update-note')
+
+  return {
+    title: t('metadata.title'),
+  }
+}
+
+type Params = { params: Promise<{ meldingId: number; noteId: number }> }
+
+export default async ({ params }: Params) => {
+  const { meldingId, noteId } = await params
+
+  const { data, error } = await getMeldingByMeldingIdNoteByNoteId({ path: { melding_id: meldingId, note_id: noteId } })
+
+  if (error) throw new Error('Failed to fetch note.')
+
+  return <UpdateNote meldingId={meldingId} note={data} noteId={noteId} />
+}

--- a/apps/back-office/src/mocks/endpoints.ts
+++ b/apps/back-office/src/mocks/endpoints.ts
@@ -15,6 +15,7 @@ export const ENDPOINTS = {
   GET_MELDING_BY_MELDING_ID_ATTACHMENTS: '/melding/:id/attachments',
   GET_MELDING_BY_MELDING_ID_NEXT_POSSIBLE_STATES: '/melding/:id/next_possible_states',
   GET_MELDING_BY_MELDING_ID_NOTE: '/melding/:id/note',
+  GET_MELDING_BY_MELDING_ID_NOTE_BY_NOTE_ID: '/melding/:id/note/:noteId',
 
   PATCH_MELDING_BY_MELDING_ID: '/melding/:id',
   PATCH_MELDING_BY_MELDING_ID_MELDER: '/melding/:id/melder',

--- a/apps/back-office/src/mocks/handlers.ts
+++ b/apps/back-office/src/mocks/handlers.ts
@@ -32,6 +32,13 @@ export const handlers = [
     HttpResponse.json({ states: ['processing_requested', 'completed'] }),
   ),
   http.get(ENDPOINTS.GET_MELDING_BY_MELDING_ID_NOTE, () => HttpResponse.json([])),
+  http.get(ENDPOINTS.GET_MELDING_BY_MELDING_ID_NOTE_BY_NOTE_ID, () =>
+    HttpResponse.json({
+      created_at: '2025-05-26T11:56:34.081Z',
+      id: 456,
+      text: 'This is a note.',
+    }),
+  ),
 
   http.patch(ENDPOINTS.PATCH_MELDING_BY_MELDING_ID, () => new HttpResponse()),
   http.patch(ENDPOINTS.PATCH_MELDING_BY_MELDING_ID_MELDER, () =>

--- a/apps/back-office/translations/nl.json
+++ b/apps/back-office/translations/nl.json
@@ -172,7 +172,8 @@
       "created-at": "Aangemaakt op: ",
       "by": " door: "
     },
-    "add-note-link": "Notitie toevoegen"
+    "add-note-link": "Notitie toevoegen",
+    "edit-link": "Wijzig notitie"
   },
   "add-note": {
     "metadata": {
@@ -186,6 +187,20 @@
     "cancel-link": "Annuleer",
     "errors": {
       "required": "Vul een notitie in.",
+      "maxLength": "De notitie mag niet langer zijn dan {max} tekens."
+    }
+  },
+  "update-note": {
+    "metadata": {
+      "title": "Wijzig notitie - Gemeente Amsterdam"
+    },
+    "back-link": "Meldingdetails",
+    "invalid-form-alert-title": "Verbeter de fouten om uw notitie te wijzigen",
+    "title": "Wijzig notitie",
+    "label": "Wijzig notitie",
+    "submit-button": "Wijzig notitie",
+    "cancel-link": "Annuleer",
+    "errors": {
       "maxLength": "De notitie mag niet langer zijn dan {max} tekens."
     }
   },

--- a/apps/back-office/translations/nl.json
+++ b/apps/back-office/translations/nl.json
@@ -173,7 +173,8 @@
       "by": " door: "
     },
     "add-note-link": "Notitie toevoegen",
-    "edit-link": "Wijzig notitie"
+    "edit-link": "Wijzig notitie",
+    "deleted-note": "Deze notitie is verwijderd."
   },
   "add-note": {
     "metadata": {

--- a/apps/back-office/translations/nl.json
+++ b/apps/back-office/translations/nl.json
@@ -170,11 +170,13 @@
     },
     "visually-hidden-texts": {
       "created-at": "Aangemaakt op: ",
-      "by": " door: "
+      "by": " door: ",
+      "edited": " en later gewijzigd"
     },
-    "add-note-link": "Notitie toevoegen",
+    "edited": "(gewijzigd)",
     "edit-link": "Wijzig notitie",
-    "deleted-note": "Deze notitie is verwijderd."
+    "deleted-note": "Deze notitie is verwijderd.",
+    "add-note-link": "Notitie toevoegen"
   },
   "add-note": {
     "metadata": {

--- a/apps/back-office/translations/nl.json
+++ b/apps/back-office/translations/nl.json
@@ -174,8 +174,8 @@
       "edited": " en later gewijzigd"
     },
     "edited": "(gewijzigd)",
-    "edit-link": "Wijzig notitie",
     "deleted-note": "Deze notitie is verwijderd.",
+    "edit-link": "Wijzig notitie",
     "add-note-link": "Notitie toevoegen"
   },
   "add-note": {


### PR DESCRIPTION
## What

This adds a page where you can update your own notes. In the notes overview there's a link to this page and an indicator showing that a note has been edited.

## Why

Users should be able to edit their notes.

Ticket: [SIG-7376](https://gemeente-amsterdam.atlassian.net/browse/SIG-7376)

Before opening a pull request, please ensure your branch is based on `main` and targets `main`.

- [x] Includes AI-assisted code via GitHub Copilot

Check requirements when they are met (strikethrough when not applicable):

- [x] Acknowledges **[team code standards](https://github.com/Amsterdam/meldingen-frontend/tree/main/docs)**
- [x] Has **unit tests** with 100% coverage (if feasible) and all test should pass
- [x] Has **error handling** and **loading states**
- [x] Is **responsive and respects WCAG**
- [ ] ~~**Documentation** has been updated~~
- [x] **Required PR checks** have passed

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-7376]: https://gemeente-amsterdam.atlassian.net/browse/SIG-7376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ