### PR TITLE
Make rich text editor toolbar easier to use

### DIFF
--- a/apps/back-office/src/app/_components/RichTextEditor/ListIcon.tsx
+++ b/apps/back-office/src/app/_components/RichTextEditor/ListIcon.tsx
@@ -1,0 +1,19 @@
+// This icon is copied from the Amsterdam Design System React Icons package and made slightly larger.
+// TODO: Let the Amsterdam Design System team know that the icon is too small and should be updated in the package.
+
+import type { SVGProps } from 'react'
+
+export const ListIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    aria-hidden="true"
+    data-directional="true"
+    focusable="false"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path d="M2 7a1 1 0 1 0 0-2 1 1 0 0 0 0 2M5 7h18V5H5zM23 13H5v-2h18zM2 13a1 1 0 1 0 0-2 1 1 0 0 0 0 2M23 19H5v-2h18zM2 19a1 1 0 1 0 0-2 1 1 0 0 0 0 2" />
+  </svg>
+)

--- a/apps/back-office/src/app/_components/RichTextEditor/Toolbar.module.css
+++ b/apps/back-office/src/app/_components/RichTextEditor/Toolbar.module.css
@@ -4,6 +4,7 @@
   flex-wrap: wrap;
   gap: var(--ams-space-m);
   inline-size: fit-content;
+  margin-block-end: var(--ams-space-s);
 }
 
 .button {

--- a/apps/back-office/src/app/_components/RichTextEditor/Toolbar.tsx
+++ b/apps/back-office/src/app/_components/RichTextEditor/Toolbar.tsx
@@ -9,10 +9,11 @@ import {
   ListIcon,
   UndoIcon,
 } from '@amsterdam/design-system-react-icons'
-import { useKeyboardFocus } from '@amsterdam/design-system-react/dist/common/useKeyboardFocus'
 import { useEditorState } from '@tiptap/react'
 import { useTranslations } from 'next-intl'
 import { useRef, useState } from 'react'
+
+import { useKeyboardFocus } from './useKeyboardFocus'
 
 import styles from './Toolbar.module.css'
 
@@ -45,11 +46,7 @@ export const Toolbar = ({ editor, id }: Props) => {
     selector: toolbarStateSelector,
   })
 
-  const { keyDown } = useKeyboardFocus(ref as RefObject<HTMLDivElement>, {
-    focusableElements: ['.ams-icon-button:not([disabled])'],
-    horizontally: true,
-    rotating: true,
-  })
+  const { keyDown } = useKeyboardFocus(ref as RefObject<HTMLDivElement>)
 
   const getTabIndex = (button: ToolbarButton) => (activeButton === button ? 0 : -1)
 

--- a/apps/back-office/src/app/_components/RichTextEditor/Toolbar.tsx
+++ b/apps/back-office/src/app/_components/RichTextEditor/Toolbar.tsx
@@ -2,17 +2,13 @@ import type { Editor, EditorStateSnapshot } from '@tiptap/react'
 import type { RefObject } from 'react'
 
 import { IconButton } from '@amsterdam/design-system-react'
-import {
-  FormattingBoldIcon,
-  FormattingItalicIcon,
-  FormattingUnderlineIcon,
-  ListIcon,
-  UndoIcon,
-} from '@amsterdam/design-system-react-icons'
+import { FormattingBoldIcon, FormattingItalicIcon, FormattingUnderlineIcon } from '@amsterdam/design-system-react-icons'
 import { useEditorState } from '@tiptap/react'
 import { useTranslations } from 'next-intl'
 import { useRef, useState } from 'react'
 
+import { ListIcon } from './ListIcon'
+import { UndoIcon } from './UndoIcon'
 import { useKeyboardFocus } from './useKeyboardFocus'
 
 import styles from './Toolbar.module.css'
@@ -92,6 +88,7 @@ export const Toolbar = ({ editor, id }: Props) => {
         label={t('unordered-list')}
         onClick={() => editor.chain().focus().toggleBulletList().run()}
         onFocus={() => setActiveButton('bulletList')}
+        size="heading-3"
         svg={ListIcon}
         tabIndex={getTabIndex('bulletList')}
       />
@@ -101,6 +98,7 @@ export const Toolbar = ({ editor, id }: Props) => {
         label={t('undo')}
         onClick={() => editorState.canUndo && editor.chain().focus().undo().run()}
         onFocus={() => setActiveButton('undo')}
+        size="heading-3"
         svg={UndoIcon}
         tabIndex={getTabIndex('undo')}
       />

--- a/apps/back-office/src/app/_components/RichTextEditor/UndoIcon.tsx
+++ b/apps/back-office/src/app/_components/RichTextEditor/UndoIcon.tsx
@@ -1,0 +1,19 @@
+// This icon is copied from the Amsterdam Design System React Icons package and made slightly larger.
+// TODO: Let the Amsterdam Design System team know that the icon is too small and should be updated in the package.
+
+import type { SVGProps } from 'react'
+
+export const UndoIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    aria-hidden="true"
+    data-directional="true"
+    focusable="false"
+    height="19"
+    viewBox="0 0 16 19"
+    width="16"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path d="M8.18083 4.89181L9.65298 6.36396L8.23877 7.77817L4.34968 3.88909L8.23877 0L9.65298 1.41421L8.17616 2.89104C12.5131 2.98473 16 6.52973 16 10.8891C16 15.3074 12.4183 18.8891 8 18.8891C3.58172 18.8891 0 15.3074 0 10.8891C0 9.47441 0.368094 8.14265 1.01448 6.98752L2.7598 7.96417C2.27609 8.82859 2 9.82511 2 10.8891C2 14.2028 4.68629 16.8891 8 16.8891C11.3137 16.8891 14 14.2028 14 10.8891C14 7.63592 11.4109 4.98742 8.18083 4.89181Z" />
+  </svg>
+)

--- a/apps/back-office/src/app/_components/RichTextEditor/useKeyboardFocus.test.tsx
+++ b/apps/back-office/src/app/_components/RichTextEditor/useKeyboardFocus.test.tsx
@@ -1,0 +1,145 @@
+import type { RefObject } from 'react'
+
+import { fireEvent, render, screen } from '@testing-library/react'
+import { useRef } from 'react'
+import { afterEach } from 'vitest'
+
+import { useKeyboardFocus } from './useKeyboardFocus'
+
+describe('useKeyboardFocus', () => {
+  const onFocusOneMock = vi.fn()
+  const onFocusTwoMock = vi.fn()
+  const onFocusThreeMock = vi.fn()
+
+  const Component = () => {
+    const ref = useRef<HTMLDivElement>(null)
+    const { keyDown } = useKeyboardFocus(ref as RefObject<HTMLDivElement>)
+
+    return (
+      <div onKeyDown={keyDown} ref={ref} role="menu" tabIndex={0}>
+        <button className="ams-icon-button" onFocus={onFocusOneMock} type="button">
+          One
+        </button>
+        <button className="ams-icon-button" onFocus={onFocusTwoMock} type="button">
+          Two
+        </button>
+        <button className="ams-icon-button" onFocus={onFocusThreeMock} type="button">
+          Three
+        </button>
+      </div>
+    )
+  }
+
+  afterEach(() => {
+    onFocusOneMock.mockReset()
+    onFocusTwoMock.mockReset()
+    onFocusThreeMock.mockReset()
+  })
+
+  it('sets focus when using "ArrowDown" and "ArrowUp" keys', () => {
+    const { container } = render(<Component />)
+
+    const firstChild = container.firstChild as HTMLElement
+
+    expect(onFocusOneMock).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(firstChild, { key: 'ArrowDown' })
+    expect(onFocusOneMock).toHaveBeenCalledTimes(1)
+
+    fireEvent.keyDown(firstChild, { key: 'ArrowDown' })
+    expect(onFocusTwoMock).toHaveBeenCalledTimes(1)
+
+    fireEvent.keyDown(firstChild, { key: 'ArrowDown' })
+    expect(onFocusThreeMock).toHaveBeenCalledTimes(1)
+
+    fireEvent.keyDown(firstChild, { key: 'ArrowUp' })
+    expect(onFocusTwoMock).toHaveBeenCalledTimes(2)
+
+    fireEvent.keyDown(firstChild, { key: 'ArrowUp' })
+    expect(onFocusOneMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('sets focus when using "ArrowRight" and "ArrowLeft" keys', () => {
+    const { container } = render(<Component />)
+
+    const firstChild = container.firstChild as HTMLElement
+
+    fireEvent.keyDown(firstChild, { key: 'ArrowRight' })
+    expect(onFocusOneMock).toHaveBeenCalledTimes(1)
+
+    fireEvent.keyDown(firstChild, { key: 'ArrowRight' })
+    expect(onFocusTwoMock).toHaveBeenCalledTimes(1)
+
+    fireEvent.keyDown(firstChild, { key: 'ArrowLeft' })
+    expect(onFocusOneMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('rotates focused elements', () => {
+    const { container } = render(<Component />)
+
+    const firstChild = container.firstChild as HTMLElement
+
+    Array.from(Array(9).keys()).forEach(() => {
+      fireEvent.keyDown(firstChild, { key: 'ArrowDown' })
+    })
+
+    expect(onFocusOneMock).toHaveBeenCalledTimes(3)
+
+    Array.from(Array(9).keys()).forEach(() => {
+      fireEvent.keyDown(firstChild, { key: 'ArrowUp' })
+    })
+
+    expect(onFocusOneMock).toHaveBeenCalledTimes(6)
+  })
+
+  it('sets focus to first element when using "Home" key', () => {
+    const { container } = render(<Component />)
+
+    const firstChild = container.firstChild as HTMLElement
+
+    fireEvent.keyDown(firstChild, { key: 'Home' })
+
+    expect(onFocusOneMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('sets focus to last element when using "End" key', () => {
+    const { container } = render(<Component />)
+
+    const firstChild = container.firstChild as HTMLElement
+
+    fireEvent.keyDown(firstChild, {
+      key: 'End',
+    })
+
+    expect(onFocusThreeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing when ref.current is null', () => {
+    const NullRefComponent = () => {
+      const ref = useRef<HTMLDivElement>(null)
+      const { keyDown } = useKeyboardFocus(ref as RefObject<HTMLDivElement>)
+      // ref is intentionally not attached to any element so ref.current stays null
+      return <div onKeyDown={keyDown} role="menu" tabIndex={0} />
+    }
+
+    render(<NullRefComponent />)
+
+    const component = screen.getByRole('menu')
+
+    fireEvent.keyDown(component, { key: 'ArrowDown' })
+    // Should return early without focusing anything
+    expect(onFocusOneMock).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when an unhandled key is pressed', () => {
+    const { container } = render(<Component />)
+
+    const firstChild = container.firstChild as HTMLElement
+
+    fireEvent.keyDown(firstChild, { key: 'a' })
+
+    expect(onFocusOneMock).not.toHaveBeenCalled()
+    expect(onFocusTwoMock).not.toHaveBeenCalled()
+    expect(onFocusThreeMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/back-office/src/app/_components/RichTextEditor/useKeyboardFocus.ts
+++ b/apps/back-office/src/app/_components/RichTextEditor/useKeyboardFocus.ts
@@ -1,0 +1,50 @@
+// Based on https://github.com/Amsterdam/design-system/blob/develop/packages/react/src/common/useKeyboardFocus.tsx
+
+import type { KeyboardEvent, RefObject } from 'react'
+
+const KeyboardKeys = {
+  ArrowDown: 'ArrowDown',
+  ArrowLeft: 'ArrowLeft',
+  ArrowRight: 'ArrowRight',
+  ArrowUp: 'ArrowUp',
+  End: 'End',
+  Home: 'Home',
+}
+
+const FOCUSABLE_ELEMENTS = '.ams-icon-button:not([disabled])'
+
+export const useKeyboardFocus = (ref: RefObject<HTMLElement>) => {
+  const keyDown = (e: KeyboardEvent) => {
+    if (!ref.current) return
+
+    const element = ref.current
+    const focusableEls: Array<Element> = Array.from(element.querySelectorAll(FOCUSABLE_ELEMENTS))
+    const currentIndex = focusableEls.indexOf(document.activeElement as Element)
+
+    let targetElement: Element | undefined
+
+    switch (e.key) {
+      case KeyboardKeys.ArrowDown:
+      case KeyboardKeys.ArrowRight:
+        targetElement = focusableEls[currentIndex + 1] || focusableEls[0]
+        break
+      case KeyboardKeys.ArrowLeft:
+      case KeyboardKeys.ArrowUp:
+        targetElement = focusableEls[currentIndex - 1] || focusableEls[focusableEls.length - 1]
+        break
+      case KeyboardKeys.End:
+        targetElement = focusableEls[focusableEls.length - 1]
+        break
+      case KeyboardKeys.Home:
+        targetElement = focusableEls[0]
+        break
+    }
+
+    if (targetElement instanceof HTMLElement) {
+      targetElement.focus()
+      e.preventDefault()
+    }
+  }
+
+  return { keyDown }
+}

--- a/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/AddNote.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/AddNote.tsx
@@ -71,7 +71,9 @@ export const AddNote = ({ meldingId }: { meldingId: number }) => {
           <Form action={formAction} noValidate>
             <div className={styles.whiteField}>
               <Field invalid={Boolean(errorMessage)}>
-                <Label id="addNote-label">{t('label')}</Label>
+                <Label className="ams-mb-s" id="addNote-label">
+                  {t('label')}
+                </Label>
                 {errorMessage && <ErrorMessage id="addNote-error">{errorMessage}</ErrorMessage>}
                 <RichTextEditor
                   aria-describedby={getAriaDescribedBy('addNote', undefined, errorMessage)}

--- a/apps/back-office/translations/nl.json
+++ b/apps/back-office/translations/nl.json
@@ -196,10 +196,10 @@
     },
     "rich-text-editor": {
       "bold": "Vetgedrukt",
-      "italic": "Cursief",
-      "toolbar": "Werkbalk tekstopmaak",
+      "italic": "Schuingedrukt",
+      "toolbar": "Tekst opmaken",
       "underline": "Onderstreept",
-      "unordered-list": "Opsommingslijst",
+      "unordered-list": "Opsomming",
       "undo": "Ongedaan maken"
     },
     "state": {


### PR DESCRIPTION
## What

This PR improved the rich text editor toolbar in a couple of ways:

- It adds some extra margin below the label and the toolbar
- It makes the Undo and List icons a little larger
- It improves the visually hidden labels
- It allows you to use both down and right arrow keys as the next key, and up and left as the previous key

## Why

This is the result of a review by UX, these changes improve the usability of the component.

Ticket: [SIG-7377](https://gemeente-amsterdam.atlassian.net/browse/SIG-7377)

Before opening a pull request, please ensure your branch is based on `main` and targets `main`.

- [x] Includes AI-assisted code via GitHub Copilot

Check requirements when they are met (strikethrough when not applicable):

- [x] Acknowledges **[team code standards](https://github.com/Amsterdam/meldingen-frontend/tree/main/docs)**
- [ ] Has **unit tests** with 100% coverage (if feasible) and all test should pass
- [ ] ~~Has **error handling** and **loading states**~~
- [x] Is **responsive and respects WCAG**
- [ ] ~~**Documentation** has been updated~~
- [x] **Required PR checks** have passed

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-7377]: https://gemeente-amsterdam.atlassian.net/browse/SIG-7377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ