### PR TITLE
Add rich text editor to Medewerker Meldflow

### DIFF
--- a/apps/back-office/src/app/melden/MeldingForm.test.tsx
+++ b/apps/back-office/src/app/melden/MeldingForm.test.tsx
@@ -200,33 +200,39 @@ describe('MeldingForm', () => {
     expect(screen.getByRole('checkbox', { name: 'Label 2' })).not.toBeChecked()
   })
 
-  it('prefills note from formData when the action returns formData', () => {
+  it('prefills note from formData when the action returns formData', async () => {
     const formData = new FormData()
     formData.set('addNote', 'Prefilled note')
     ;(useActionState as Mock).mockReturnValueOnce([{ formData }, vi.fn()])
 
     render(<MeldingForm {...defaultProps} />)
 
+    expect(await screen.findByRole('toolbar')).toBeInTheDocument()
+
     const noteInput = screen.getByRole('textbox', { name: 'label (niet verplicht)' })
 
-    expect(noteInput).toHaveValue('Prefilled note')
+    expect(noteInput).toHaveTextContent('Prefilled note')
   })
 
-  it('prefills note from defaultValues when provided and there is no formData', () => {
+  it('prefills note from defaultValues when provided and there is no formData', async () => {
     render(<MeldingForm {...defaultProps} defaultValues={{ note: 'Existing note' }} />)
 
+    expect(await screen.findByRole('toolbar')).toBeInTheDocument()
+
     const noteInput = screen.getByRole('textbox', { name: 'label (niet verplicht)' })
 
-    expect(noteInput).toHaveValue('Existing note')
+    expect(noteInput).toHaveTextContent('Existing note')
   })
 
-  it('renders an error message connected to the note text area when there is a validation error for the note field', () => {
+  it('renders an error message connected to the note text area when there is a validation error for the note field', async () => {
     ;(useActionState as Mock).mockReturnValueOnce([
       { validationErrors: [{ key: 'addNote', message: 'Note error' }] },
       vi.fn(),
     ])
 
     render(<MeldingForm {...defaultProps} />)
+
+    expect(await screen.findByRole('toolbar')).toBeInTheDocument()
 
     const input = screen.getByRole('textbox', { name: 'label (niet verplicht)' })
 

--- a/apps/back-office/src/app/melden/_components/NoteField/NoteField.test.tsx
+++ b/apps/back-office/src/app/melden/_components/NoteField/NoteField.test.tsx
@@ -3,17 +3,21 @@ import { render, screen } from '@testing-library/react'
 import { NoteField } from './NoteField'
 
 describe('NoteField', () => {
-  it('renders the note textarea with the default value', () => {
+  it('renders the note rich text editor with the default value', async () => {
     render(<NoteField defaultValue="Some note text" />)
+
+    expect(await screen.findByRole('toolbar')).toBeInTheDocument()
 
     const textArea = screen.getByRole('textbox', { name: 'label (niet verplicht)' })
 
     expect(textArea).toBeInTheDocument()
-    expect(textArea).toHaveValue('Some note text')
+    expect(textArea).toHaveTextContent('Some note text')
   })
 
-  it('renders an error message when there is one', () => {
+  it('renders an error message when there is one', async () => {
     render(<NoteField defaultValue="" errorMessage="Test error message" />)
+
+    expect(await screen.findByRole('toolbar')).toBeInTheDocument()
 
     const textAreaWithErrorMessage = screen.getByRole('textbox', {
       description: 'Invoerfout:Test error message',
@@ -23,8 +27,10 @@ describe('NoteField', () => {
     expect(textAreaWithErrorMessage).toBeInTheDocument()
   })
 
-  it('marks the Field and textarea as invalid when there is an error message', () => {
+  it('marks the Field and textarea as invalid when there is an error message', async () => {
     const { container } = render(<NoteField defaultValue="" errorMessage="Test error message" />)
+
+    expect(await screen.findByRole('toolbar')).toBeInTheDocument()
 
     const field = container.firstChild
     expect(field).toHaveClass('ams-field--invalid')

--- a/apps/back-office/src/app/melden/_components/NoteField/NoteField.tsx
+++ b/apps/back-office/src/app/melden/_components/NoteField/NoteField.tsx
@@ -1,7 +1,9 @@
-import { ErrorMessage, Field, Label, TextArea } from '@amsterdam/design-system-react'
+import { ErrorMessage, Field, Label } from '@amsterdam/design-system-react'
 import { useTranslations } from 'next-intl'
 
 import { getAriaDescribedBy } from '@meldingen/form-renderer'
+
+import { RichTextEditor } from '~/app/_components'
 
 type Props = {
   defaultValue: string
@@ -13,17 +15,17 @@ export const NoteField = ({ defaultValue, errorMessage }: Props) => {
 
   return (
     <Field invalid={Boolean(errorMessage)}>
-      <Label htmlFor="addNote" optional>
+      <Label id="addNote-label" optional>
         {t('label')}
       </Label>
       {errorMessage && <ErrorMessage id="addNote-error">{errorMessage}</ErrorMessage>}
-      <TextArea
+      <RichTextEditor
         aria-describedby={getAriaDescribedBy('addNote', undefined, errorMessage)}
+        aria-labelledby="addNote-label"
         defaultValue={defaultValue}
         id="addNote"
         invalid={Boolean(errorMessage)}
         name="addNote"
-        rows={4}
       />
     </Field>
   )

--- a/apps/back-office/src/app/melden/actions.test.ts
+++ b/apps/back-office/src/app/melden/actions.test.ts
@@ -12,6 +12,14 @@ vi.mock('next/navigation', () => ({
   redirect: vi.fn(),
 }))
 
+// RichTextEditor submits the ProseMirror doc as JSON, so tests build that same shape here
+// instead of appending plain markdown/text.
+const noteDoc = (text: string) =>
+  JSON.stringify({
+    content: [{ content: text ? [{ text, type: 'text' }] : [], type: 'paragraph' }],
+    type: 'doc',
+  })
+
 const createFormData = (fields: Record<string, string> = {}): FormData => {
   const formData = new FormData()
 
@@ -56,7 +64,7 @@ describe('postMeldingForm', () => {
     const formData = new FormData()
     formData.set('primary', 'Test')
     formData.set('source', 'Test')
-    formData.set('addNote', 'a'.repeat(MAX_NOTE_LENGTH + 1))
+    formData.set('addNote', noteDoc('a'.repeat(MAX_NOTE_LENGTH + 1)))
 
     const result = await postMeldingForm({ requiredErrorMessage: 'Dit veld is verplicht.' }, null, formData)
 
@@ -68,7 +76,7 @@ describe('postMeldingForm', () => {
 
   it('returns 3 validation errors when primary and source questions are not answered and note is too long', async () => {
     const formData = new FormData()
-    formData.set('addNote', 'a'.repeat(MAX_NOTE_LENGTH + 1))
+    formData.set('addNote', noteDoc('a'.repeat(MAX_NOTE_LENGTH + 1)))
 
     const result = await postMeldingForm({ requiredErrorMessage: 'Dit veld is verplicht.' }, null, formData)
 
@@ -270,7 +278,7 @@ describe('postMeldingForm', () => {
     const spy = vi.spyOn(apiClientProxy, 'patchMeldingByMeldingIdNoteByNoteId')
 
     const formData = createFormData()
-    formData.set('addNote', 'Test note')
+    formData.set('addNote', noteDoc('Test note'))
 
     await postMeldingForm(
       {
@@ -298,7 +306,7 @@ describe('postMeldingForm', () => {
     const spy = vi.spyOn(apiClientProxy, 'postMeldingByMeldingIdNote')
 
     const formData = createFormData()
-    formData.set('addNote', 'Test note')
+    formData.set('addNote', noteDoc('Test note'))
 
     await postMeldingForm(
       {
@@ -348,7 +356,7 @@ describe('postMeldingForm', () => {
     )
 
     const formData = createFormData()
-    formData.set('addNote', 'Test note')
+    formData.set('addNote', noteDoc('Test note'))
 
     const result = await postMeldingForm(
       {

--- a/apps/back-office/src/app/melden/actions.ts
+++ b/apps/back-office/src/app/melden/actions.ts
@@ -8,6 +8,7 @@ import type { MeldingOutput } from '@meldingen/api-client'
 import type { MeldingData } from './types'
 import type { FormState } from '~/types'
 
+import { parseNoteDocument } from '../_utils/parseNoteDocument'
 import { hasValidationErrors } from './_utils/hasValidationErrors'
 import {
   patchMeldingByMeldingId,
@@ -58,21 +59,19 @@ const createOrUpdateMelding = async (text: string, id?: number, token?: string) 
   }
 }
 
-const createOrUpdateNote = async (text: string, meldingId: number, noteId?: number) => {
+const createOrUpdateNote = async (isEmpty: boolean, markdown: string, meldingId: number, noteId?: number) => {
   if (noteId) {
     return await patchMeldingByMeldingIdNoteByNoteId({
-      body: { text },
+      body: { text: markdown },
       path: { melding_id: meldingId, note_id: noteId },
     })
   }
 
   // If the note text is empty, we don't want to create a new note
   // It is allowed to update an existing note with empty text
-  // TODO: this check will become unreliable when we implement the WYSIWYG editor, because empty text can contain Markdown operators
-  // (e.g. `*` or `_`). Revisit this check at that point.
-  if (text.trim() !== '') {
+  if (!isEmpty) {
     return await postMeldingByMeldingIdNote({
-      body: { text },
+      body: { text: markdown },
       path: { melding_id: meldingId },
     })
   }
@@ -87,11 +86,17 @@ export const postMeldingForm = async (
 
   const formDataObj = Object.fromEntries(formData)
 
+  const { characterCount, isEmpty, markdown } = parseNoteDocument(formDataObj.addNote)
+
+  // Replace the submitted JSON with the derived markdown, so RichTextEditor can reload it as
+  // its `defaultValue` (via contentType: 'markdown') if the form is redisplayed after an error.
+  formData.set('addNote', markdown)
+
   // Return validation errors if required fields are missing
   const validationErrors = [
     ...(!formDataObj.primary ? [{ key: 'primary', message: requiredErrorMessage }] : []),
     ...(!formDataObj.source ? [{ key: 'source', message: t('source.error') }] : []),
-    ...(formDataObj.addNote && formDataObj.addNote.toString().length > MAX_NOTE_LENGTH
+    ...(characterCount > MAX_NOTE_LENGTH
       ? [{ key: 'addNote', message: t('note.error', { max: MAX_NOTE_LENGTH }) }]
       : []),
   ]
@@ -153,7 +158,7 @@ export const postMeldingForm = async (
 
   if (updateMeldingError) return { formData, systemError: updateMeldingError }
 
-  const result = await createOrUpdateNote(formDataObj.addNote.toString(), meldingData.id, existingNoteId)
+  const result = await createOrUpdateNote(isEmpty, markdown, meldingData.id, existingNoteId)
 
   if (result?.error) return { formData, systemError: result.error }
 


### PR DESCRIPTION
## What

This uses the rich text editor on the first page of the Medewerker Meldflow, so Medewerkers can use rich text in the notes they add to a Melding. 

## Why

Notes can be rich text everywhere, so we should add this here. 

Ticket: [SIG-7432](https://gemeente-amsterdam.atlassian.net/browse/SIG-7432)

Before opening a pull request, please ensure your branch is based on `main` and targets `main`.

- [x] Includes AI-assisted code via GitHub Copilot

Check requirements when they are met (strikethrough when not applicable):

- [x] Acknowledges **[team code standards](https://github.com/Amsterdam/meldingen-frontend/tree/main/docs)**
- [x] Has **unit tests** with 100% coverage (if feasible) and all test should pass
- [x] Has **error handling** and **loading states**
- [x] Is **responsive and respects WCAG**
- [ ] ~~**Documentation** has been updated~~
- [x] **Required PR checks** have passed

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-7432]: https://gemeente-amsterdam.atlassian.net/browse/SIG-7432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ