### PR TITLE
Add document title hook to Back Office and use on all form pages

### DIFF
--- a/apps/back-office/src/app/_utils/useDocumentTitleOnError.test.ts
+++ b/apps/back-office/src/app/_utils/useDocumentTitleOnError.test.ts
@@ -1,0 +1,50 @@
+import { useDocumentTitleOnError } from './useDocumentTitleOnError'
+
+describe('useDocumentTitleOnError', () => {
+  const baseDocumentTitle = 'Test title'
+
+  it('returns original title when there are no errors', () => {
+    const title = useDocumentTitleOnError({
+      baseDocumentTitle,
+    })
+
+    expect(title).toBe(baseDocumentTitle)
+  })
+
+  it('returns API error title and original title when there is an API error', () => {
+    const title = useDocumentTitleOnError({
+      baseDocumentTitle,
+      hasApiError: true,
+    })
+
+    expect(title).toBe(`api-error-alert.heading - ${baseDocumentTitle}`)
+  })
+
+  it('returns the given API error message instead of the default when provided', () => {
+    const title = useDocumentTitleOnError({
+      apiErrorMessage: 'Custom error',
+      baseDocumentTitle,
+      hasApiError: true,
+    })
+
+    expect(title).toBe(`Custom error - ${baseDocumentTitle}`)
+  })
+
+  it('returns original title when validationErrorCount is 0', () => {
+    const title = useDocumentTitleOnError({
+      baseDocumentTitle,
+      validationErrorCount: 0,
+    })
+
+    expect(title).toBe(baseDocumentTitle)
+  })
+
+  it('returns error count label and original title when validationErrorCount is > 0', () => {
+    const title = useDocumentTitleOnError({
+      baseDocumentTitle,
+      validationErrorCount: 3,
+    })
+
+    expect(title).toBe(`document-title-error-count-prefix ${baseDocumentTitle}`)
+  })
+})

--- a/apps/back-office/src/app/_utils/useDocumentTitleOnError.test.ts
+++ b/apps/back-office/src/app/_utils/useDocumentTitleOnError.test.ts
@@ -4,18 +4,13 @@ describe('useDocumentTitleOnError', () => {
   const baseDocumentTitle = 'Test title'
 
   it('returns original title when there are no errors', () => {
-    const title = useDocumentTitleOnError({
-      baseDocumentTitle,
-    })
+    const title = useDocumentTitleOnError({ baseDocumentTitle })
 
     expect(title).toBe(baseDocumentTitle)
   })
 
   it('returns API error title and original title when there is an API error', () => {
-    const title = useDocumentTitleOnError({
-      baseDocumentTitle,
-      hasApiError: true,
-    })
+    const title = useDocumentTitleOnError({ baseDocumentTitle, hasApiError: true })
 
     expect(title).toBe(`api-error-alert.heading - ${baseDocumentTitle}`)
   })
@@ -31,19 +26,13 @@ describe('useDocumentTitleOnError', () => {
   })
 
   it('returns original title when validationErrorCount is 0', () => {
-    const title = useDocumentTitleOnError({
-      baseDocumentTitle,
-      validationErrorCount: 0,
-    })
+    const title = useDocumentTitleOnError({ baseDocumentTitle, validationErrorCount: 0 })
 
     expect(title).toBe(baseDocumentTitle)
   })
 
   it('returns error count label and original title when validationErrorCount is > 0', () => {
-    const title = useDocumentTitleOnError({
-      baseDocumentTitle,
-      validationErrorCount: 3,
-    })
+    const title = useDocumentTitleOnError({ baseDocumentTitle, validationErrorCount: 3 })
 
     expect(title).toBe(`document-title-error-count-prefix ${baseDocumentTitle}`)
   })

--- a/apps/back-office/src/app/_utils/useDocumentTitleOnError.ts
+++ b/apps/back-office/src/app/_utils/useDocumentTitleOnError.ts
@@ -1,0 +1,27 @@
+import { useTranslations } from 'next-intl'
+
+type Args = {
+  apiErrorMessage?: string
+  baseDocumentTitle: string
+  hasApiError?: boolean
+  validationErrorCount?: number
+}
+
+export const useDocumentTitleOnError = ({
+  apiErrorMessage,
+  baseDocumentTitle,
+  hasApiError,
+  validationErrorCount,
+}: Args) => {
+  const t = useTranslations('shared')
+
+  if (validationErrorCount && validationErrorCount > 0) {
+    return `${t('document-title-error-count-prefix', { count: validationErrorCount })} ${baseDocumentTitle}`
+  }
+
+  if (hasApiError) {
+    return `${apiErrorMessage ?? t('api-error-alert.heading')} - ${baseDocumentTitle}`
+  }
+
+  return baseDocumentTitle
+}

--- a/apps/back-office/src/app/melden/MeldingForm.test.tsx
+++ b/apps/back-office/src/app/melden/MeldingForm.test.tsx
@@ -41,9 +41,10 @@ describe('MeldingForm', () => {
     expect(input).toBeInTheDocument()
     expect(description).toBeInTheDocument()
     expect(submitButton).toBeInTheDocument()
+    expect(document.title).toBe('metadata.title')
   })
 
-  it('renders an API error alert when there is one', () => {
+  it('renders an API error alert with the correct document title when there is an API error', () => {
     ;(useActionState as Mock).mockReturnValueOnce([{ apiError: 'Test error message' }, vi.fn(), false])
 
     const { container } = render(<MeldingForm {...defaultProps} />)
@@ -51,9 +52,10 @@ describe('MeldingForm', () => {
     const alert = container.querySelector('.ams-alert')
 
     expect(alert).toBeInTheDocument()
+    expect(document.title).toBe('api-error-alert.heading - metadata.title')
   })
 
-  it('renders an Invalid Form Alert when there are validation errors', () => {
+  it('renders an Invalid Form Alert with the correct document title when there are validation errors', () => {
     ;(useActionState as Mock).mockReturnValueOnce([
       { validationErrors: [{ key: 'key1', message: 'Test error message' }] },
       vi.fn(),
@@ -66,6 +68,7 @@ describe('MeldingForm', () => {
 
     expect(link).toBeInTheDocument()
     expect(link).toHaveAttribute('href', '#key1')
+    expect(document.title).toBe('document-title-error-count-prefix metadata.title')
   })
 
   it('renders an error message connected to the primary text area when there is a validation error for the primary field', () => {

--- a/apps/back-office/src/app/melden/MeldingForm.tsx
+++ b/apps/back-office/src/app/melden/MeldingForm.tsx
@@ -12,6 +12,7 @@ import { Column, Paragraph } from '@meldingen/ui'
 import type { MeldingData } from './types'
 import type { FormState } from '~/types'
 
+import { useDocumentTitleOnError } from '../_utils/useDocumentTitleOnError'
 import { LabelsField, NoteField, PrimaryField, SourceField, UrgencyField } from './_components'
 import { postMeldingForm } from './actions'
 import { ApiErrorAlert, InvalidFormAlert } from '~/app/_components'
@@ -73,6 +74,13 @@ export const MeldingForm = ({
   const { labelsDefaultValues, noteDefaultValue, primaryDefaultValue, sourceDefaultValue, urgencyDefaultValue } =
     calculateDefaultValues(formData, defaultValues)
 
+  // Update document title when there are validation errors or an API error
+  const documentTitle = useDocumentTitleOnError({
+    baseDocumentTitle: t('metadata.title'),
+    hasApiError: Boolean(apiError),
+    validationErrorCount: validationErrors?.length ?? undefined,
+  })
+
   useEffect(() => {
     if (apiError) {
       // TODO: Log the error to an error reporting service
@@ -92,6 +100,7 @@ export const MeldingForm = ({
       gapVertical="large"
       paddingVertical="x-large"
     >
+      <title>{documentTitle}</title>
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 6 }} start={{ narrow: 1, medium: 2, wide: 2 }}>
         {Boolean(apiError) && <ApiErrorAlert shouldFocus={!isPending} />}
         {validationErrors && <InvalidFormAlert errors={validationErrors} shouldFocus={!isPending} />}

--- a/apps/back-office/src/app/melden/page.test.tsx
+++ b/apps/back-office/src/app/melden/page.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { http, HttpResponse } from 'msw'
 
 import { MeldingForm } from './MeldingForm'
-import Page, { generateMetadata } from './page'
+import Page from './page'
 import { melding, textAreaComponent } from '~/mocks/data'
 import { ENDPOINTS } from '~/mocks/endpoints'
 import { server } from '~/mocks/node'
@@ -10,14 +10,6 @@ import { server } from '~/mocks/node'
 vi.mock('./MeldingForm', () => ({
   MeldingForm: vi.fn(() => <div>MeldingForm Component</div>),
 }))
-
-describe('generateMetadata', () => {
-  it('returns the correct metadata title', async () => {
-    const metadata = await generateMetadata()
-
-    expect(metadata).toEqual({ title: 'metadata.title' })
-  })
-})
 
 describe('Page', () => {
   const sources = [

--- a/apps/back-office/src/app/melden/page.tsx
+++ b/apps/back-office/src/app/melden/page.tsx
@@ -1,7 +1,3 @@
-import type { Metadata } from 'next'
-
-import { getTranslations } from 'next-intl/server'
-
 import type { MeldingOutput, NoteRetrieveOutput, StaticFormTextAreaComponentOutput } from '@meldingen/api-client'
 
 import { MeldingForm } from './MeldingForm'
@@ -18,14 +14,6 @@ import {
 // TODO: Force dynamic rendering for now, because the api isn't accessible in the pipeline yet.
 // We can remove this when the api is deployed.
 export const dynamic = 'force-dynamic'
-
-export const generateMetadata = async (): Promise<Metadata> => {
-  const t = await getTranslations('melding-form')
-
-  return {
-    title: t('metadata.title'),
-  }
-}
 
 const fetchPrimaryTextArea = async () => {
   const { data: staticFormsData, error: staticFormsError } = await getStaticForm()

--- a/apps/back-office/src/app/melding/[meldingId]/notities/[noteId]/wijzigen/UpdateNote.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/[noteId]/wijzigen/UpdateNote.test.tsx
@@ -25,6 +25,12 @@ const defaultProps = {
 }
 
 describe('UpdateNote', () => {
+  it('renders the component with the correct document title', () => {
+    render(<UpdateNote {...defaultProps} />)
+
+    expect(document.title).toBe('metadata.title')
+  })
+
   it('renders the back link', () => {
     render(<UpdateNote {...defaultProps} />)
 
@@ -55,7 +61,7 @@ describe('UpdateNote', () => {
     expect(cancelLink).toHaveAttribute('href', '/melding/123')
   })
 
-  it('displays an API error alert when there is one', () => {
+  it('displays an API error alert with the correct document title when there is an API error', () => {
     ;(useActionState as Mock).mockReturnValueOnce([{ apiError: { detail: 'Something went wrong' } }, vi.fn(), false])
 
     const { container } = render(<UpdateNote {...defaultProps} />)
@@ -63,9 +69,10 @@ describe('UpdateNote', () => {
     const alert = container.querySelector('.ams-alert')
 
     expect(alert).toBeInTheDocument()
+    expect(document.title).toBe('api-error-alert.heading - metadata.title')
   })
 
-  it('displays an invalid form alert when there are validation errors', async () => {
+  it('displays an invalid form alert with the correct document title when there are validation errors', async () => {
     const formData = new FormData()
     formData.append('updateNote', 'Some note text')
     ;(useActionState as Mock).mockReturnValueOnce([
@@ -80,6 +87,7 @@ describe('UpdateNote', () => {
 
     expect(screen.getByRole('link', { name: 'Error message' })).toBeInTheDocument()
     expect(screen.getByRole('textbox', { name: 'label' })).toHaveTextContent('Some note text')
+    expect(document.title).toBe('document-title-error-count-prefix metadata.title')
   })
 
   it('renders a default value in the Rich Text Editor when provided', async () => {

--- a/apps/back-office/src/app/melding/[meldingId]/notities/[noteId]/wijzigen/UpdateNote.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/[noteId]/wijzigen/UpdateNote.tsx
@@ -13,6 +13,7 @@ import { BackLink } from '../../../_components/BackLink'
 import { CancelLink } from '../../../_components/CancelLink'
 import { postUpdateNoteForm } from './actions'
 import { ApiErrorAlert, InvalidFormAlert, RichTextEditor } from '~/app/_components'
+import { useDocumentTitleOnError } from '~/app/_utils/useDocumentTitleOnError'
 
 import styles from './UpdateNote.module.css'
 
@@ -30,6 +31,13 @@ export const UpdateNote = ({ meldingId, note }: Props) => {
 
   const t = useTranslations('update-note')
 
+  // Update document title when there are validation errors or an API error
+  const documentTitle = useDocumentTitleOnError({
+    baseDocumentTitle: t('metadata.title'),
+    hasApiError: Boolean(apiError),
+    validationErrorCount: validationErrors?.length ?? undefined,
+  })
+
   useEffect(() => {
     if (apiError) {
       // TODO: Log the error to an error reporting service
@@ -43,6 +51,7 @@ export const UpdateNote = ({ meldingId, note }: Props) => {
 
   return (
     <div className="ams-page__area--body">
+      <title>{documentTitle}</title>
       <BackLink href={`/melding/${meldingId}`}>{t('back-link')}</BackLink>
       <Grid as="main" gapVertical="large">
         <Grid.Cell appearance="transparent" span={{ narrow: 4, medium: 6, wide: 6 }}>

--- a/apps/back-office/src/app/melding/[meldingId]/notities/[noteId]/wijzigen/page.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/[noteId]/wijzigen/page.test.tsx
@@ -2,21 +2,13 @@ import { render, screen } from '@testing-library/react'
 import { http, HttpResponse } from 'msw'
 import { vi } from 'vitest'
 
-import Page, { generateMetadata } from './page'
+import Page from './page'
 import { ENDPOINTS } from '~/mocks/endpoints'
 import { server } from '~/mocks/node'
 
 vi.mock('./UpdateNote', () => ({
   UpdateNote: vi.fn(() => <div>UpdateNote Component</div>),
 }))
-
-describe('generateMetadata', () => {
-  it('returns the correct metadata title', async () => {
-    const metadata = await generateMetadata()
-
-    expect(metadata).toEqual({ title: 'metadata.title' })
-  })
-})
 
 describe('Page', () => {
   it('renders', async () => {

--- a/apps/back-office/src/app/melding/[meldingId]/notities/[noteId]/wijzigen/page.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/[noteId]/wijzigen/page.tsx
@@ -1,17 +1,5 @@
-import type { Metadata } from 'next'
-
-import { getTranslations } from 'next-intl/server'
-
 import { UpdateNote } from './UpdateNote'
 import { getMeldingByMeldingIdNoteByNoteId } from '~/app/_api-client/proxy'
-
-export const generateMetadata = async (): Promise<Metadata> => {
-  const t = await getTranslations('update-note')
-
-  return {
-    title: t('metadata.title'),
-  }
-}
 
 type Params = { params: Promise<{ meldingId: number; noteId: number }> }
 

--- a/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/AddNote.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/AddNote.test.tsx
@@ -17,6 +17,12 @@ vi.mock('react', async (importOriginal) => {
 const defaultProps = { meldingId: 123 }
 
 describe('AddNote', () => {
+  it('renders the component with the correct document title', () => {
+    render(<AddNote {...defaultProps} />)
+
+    expect(document.title).toBe('metadata.title')
+  })
+
   it('renders the back link', () => {
     render(<AddNote {...defaultProps} />)
 
@@ -47,7 +53,7 @@ describe('AddNote', () => {
     expect(cancelLink).toHaveAttribute('href', '/melding/123')
   })
 
-  it('displays an API error alert when there is one', () => {
+  it('displays an API error alert with the correct document title when there is an API error', () => {
     ;(useActionState as Mock).mockReturnValueOnce([{ apiError: { detail: 'Something went wrong' } }, vi.fn(), false])
 
     const { container } = render(<AddNote {...defaultProps} />)
@@ -55,9 +61,10 @@ describe('AddNote', () => {
     const alert = container.querySelector('.ams-alert')
 
     expect(alert).toBeInTheDocument()
+    expect(document.title).toBe('api-error-alert.heading - metadata.title')
   })
 
-  it('displays an invalid form alert when there are validation errors', async () => {
+  it('displays an invalid form alert with the correct document title when there are validation errors', async () => {
     const formData = new FormData()
     formData.append('addNote', 'Some note text')
     ;(useActionState as Mock).mockReturnValueOnce([
@@ -72,6 +79,8 @@ describe('AddNote', () => {
 
     expect(screen.getByRole('link', { name: 'Error message' })).toBeInTheDocument()
     expect(screen.getByRole('textbox', { name: 'label' })).toHaveTextContent('Some note text')
+
+    expect(document.title).toBe('document-title-error-count-prefix metadata.title')
   })
 
   it('submits the form when the submit button is clicked', async () => {

--- a/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/AddNote.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/AddNote.tsx
@@ -11,6 +11,7 @@ import { BackLink } from '../../_components/BackLink'
 import { CancelLink } from '../../_components/CancelLink'
 import { postAddNoteForm } from './actions'
 import { ApiErrorAlert, InvalidFormAlert, RichTextEditor } from '~/app/_components'
+import { useDocumentTitleOnError } from '~/app/_utils/useDocumentTitleOnError'
 
 import styles from './AddNote.module.css'
 
@@ -26,6 +27,13 @@ export const AddNote = ({ meldingId }: { meldingId: number }) => {
 
   const t = useTranslations('add-note')
 
+  // Update document title when there are validation errors or an API error
+  const documentTitle = useDocumentTitleOnError({
+    baseDocumentTitle: t('metadata.title'),
+    hasApiError: Boolean(apiError),
+    validationErrorCount: validationErrors?.length ?? undefined,
+  })
+
   useEffect(() => {
     if (apiError) {
       // TODO: Log the error to an error reporting service
@@ -39,6 +47,7 @@ export const AddNote = ({ meldingId }: { meldingId: number }) => {
 
   return (
     <div className="ams-page__area--body">
+      <title>{documentTitle}</title>
       <BackLink href={`/melding/${meldingId}`}>{t('back-link')}</BackLink>
       <Grid as="main" gapVertical="large">
         <Grid.Cell appearance="transparent" span={{ narrow: 4, medium: 6, wide: 6 }}>

--- a/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/page.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/page.test.tsx
@@ -1,19 +1,11 @@
 import { render, screen } from '@testing-library/react'
 import { vi } from 'vitest'
 
-import Page, { generateMetadata } from './page'
+import Page from './page'
 
 vi.mock('./AddNote', () => ({
   AddNote: vi.fn(() => <div>AddNote Component</div>),
 }))
-
-describe('generateMetadata', () => {
-  it('returns the correct metadata title', async () => {
-    const metadata = await generateMetadata()
-
-    expect(metadata).toEqual({ title: 'metadata.title' })
-  })
-})
 
 describe('Page', () => {
   it('renders', async () => {

--- a/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/page.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/toevoegen/page.tsx
@@ -1,16 +1,4 @@
-import type { Metadata } from 'next'
-
-import { getTranslations } from 'next-intl/server'
-
 import { AddNote } from './AddNote'
-
-export const generateMetadata = async (): Promise<Metadata> => {
-  const t = await getTranslations('add-note')
-
-  return {
-    title: t('metadata.title'),
-  }
-}
 
 type Params = { params: Promise<{ meldingId: number }> }
 

--- a/apps/back-office/src/app/melding/[meldingId]/wijzig-labels/ChangeLabels.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/wijzig-labels/ChangeLabels.test.tsx
@@ -28,6 +28,12 @@ const defaultProps: Props = {
 }
 
 describe('ChangeLabels', () => {
+  it('renders the component with the correct document title', () => {
+    render(<ChangeLabels {...defaultProps} />)
+
+    expect(document.title).toBe('metadata.title')
+  })
+
   it('renders the backlink', () => {
     render(<ChangeLabels {...defaultProps} />)
 
@@ -71,7 +77,7 @@ describe('ChangeLabels', () => {
     expect(screen.getByRole('checkbox', { name: 'Label 3' })).not.toBeChecked()
   })
 
-  it('displays an API error Alert and last selected labels when action returns an API error', () => {
+  it('displays an API error Alert with the correct document title and last selected labels when action returns an API error', () => {
     ;(useActionState as Mock).mockReturnValueOnce([
       { apiError: 'Test error', labelIdsFromAction: [0, 2] },
       vi.fn(),
@@ -80,11 +86,16 @@ describe('ChangeLabels', () => {
 
     const { container } = render(<ChangeLabels {...defaultProps} />)
 
+    // Alert
     const alert = container.querySelector('.ams-alert')
     expect(alert).toBeInTheDocument()
     expect(alert).toHaveTextContent('errors.labels-change-failed-heading')
     expect(alert).toHaveTextContent('description')
 
+    // Doc title
+    expect(document.title).toBe('errors.labels-change-failed-heading - metadata.title')
+
+    // Checkboxes
     expect(screen.getByRole('checkbox', { name: 'Label 1' })).toBeChecked()
     expect(screen.getByRole('checkbox', { name: 'Label 3' })).toBeChecked()
   })

--- a/apps/back-office/src/app/melding/[meldingId]/wijzig-labels/ChangeLabels.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/wijzig-labels/ChangeLabels.tsx
@@ -12,6 +12,7 @@ import { BackLink } from '../_components/BackLink'
 import { CancelLink } from '../_components/CancelLink'
 import { postChangeLabelsForm } from './actions'
 import { ApiErrorAlert } from '~/app/_components'
+import { useDocumentTitleOnError } from '~/app/_utils/useDocumentTitleOnError'
 
 import styles from './ChangeLabels.module.css'
 
@@ -35,8 +36,12 @@ export const ChangeLabels = ({ currentLabelIds, labels, meldingId, publicId }: P
 
   const t = useTranslations('change-labels')
 
-  const baseTitle = t('metadata.title')
-  const documentTitle = apiError ? `${t('errors.labels-change-failed-heading')} - ${baseTitle}` : baseTitle
+  // Update document title when there is an API error
+  const documentTitle = useDocumentTitleOnError({
+    apiErrorMessage: apiError ? t('errors.labels-change-failed-heading') : undefined,
+    baseDocumentTitle: t('metadata.title'),
+    hasApiError: Boolean(apiError),
+  })
 
   useEffect(() => {
     if (apiError) {

--- a/apps/back-office/src/app/melding/[meldingId]/wijzig-status/ChangeState.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/wijzig-status/ChangeState.test.tsx
@@ -22,6 +22,12 @@ const defaultProps = {
 }
 
 describe('ChangeState', () => {
+  it('renders the component with the correct document title', () => {
+    render(<ChangeState {...defaultProps} />)
+
+    expect(document.title).toBe('metadata.title')
+  })
+
   it('renders the back link', () => {
     render(<ChangeState {...defaultProps} />)
 
@@ -60,7 +66,7 @@ describe('ChangeState', () => {
     expect(select).toHaveValue('processing')
   })
 
-  it('displays the correct error message and default value when the action returns an error with type invalid-state', () => {
+  it('displays the correct error message, document title and default value when the action returns an error with type invalid-state', () => {
     ;(useActionState as Mock).mockReturnValueOnce([
       { apiError: { type: 'invalid-state' }, meldingStateFromAction: 'completed' },
       vi.fn(),
@@ -73,13 +79,19 @@ describe('ChangeState', () => {
     const alert = container.querySelector('.ams-alert')
     const heading = within(alert as HTMLElement).getByRole('heading', { name: 'errors.invalid-state.heading' })
 
+    // Alert
     expect(alert).toBeInTheDocument()
     expect(heading).toBeInTheDocument()
     expect(alert).toHaveTextContent('errors.invalid-state.description')
+
+    // Doc title
+    expect(document.title).toBe('errors.invalid-state.heading - metadata.title')
+
+    // Select
     expect(select).toHaveValue('completed')
   })
 
-  it('displays the correct error message and default value when the action returns an error with type state-change-failed', () => {
+  it('displays the correct error message, document title and default value when the action returns an error with type state-change-failed', () => {
     ;(useActionState as Mock).mockReturnValueOnce([
       { apiError: { type: 'state-change-failed' }, meldingStateFromAction: 'completed' },
       vi.fn(),
@@ -92,9 +104,15 @@ describe('ChangeState', () => {
     const alert = container.querySelector('.ams-alert')
     const heading = within(alert as HTMLElement).getByRole('heading', { name: 'errors.state-change-failed.heading' })
 
+    // Alert
     expect(alert).toBeInTheDocument()
     expect(heading).toBeInTheDocument()
     expect(alert).toHaveTextContent('errors.state-change-failed.description')
+
+    // Doc title
+    expect(document.title).toBe('errors.state-change-failed.heading - metadata.title')
+
+    // Select
     expect(select).toHaveValue('completed')
   })
 

--- a/apps/back-office/src/app/melding/[meldingId]/wijzig-status/ChangeState.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/wijzig-status/ChangeState.tsx
@@ -12,6 +12,7 @@ import { BackLink } from '../_components/BackLink'
 import { CancelLink } from '../_components/CancelLink'
 import { postChangeStateForm } from './actions'
 import { ApiErrorAlert } from '~/app/_components'
+import { useDocumentTitleOnError } from '~/app/_utils/useDocumentTitleOnError'
 
 import styles from './ChangeState.module.css'
 
@@ -30,20 +31,6 @@ const initialState: {
   meldingStateFromAction?: string
 } = {}
 
-type ArgsType = {
-  errorMessage: string
-  hasError: boolean
-  originalDocTitle: string
-}
-
-const getDocumentTitleOnError = ({ errorMessage, hasError, originalDocTitle }: ArgsType) => {
-  if (hasError) {
-    return `${errorMessage} - ${originalDocTitle}`
-  }
-
-  return originalDocTitle
-}
-
 export const ChangeState = ({ meldingId, meldingState, possibleStates, publicId }: Props) => {
   const postChangeStateFormWithMeldingId = postChangeStateForm.bind(null, { currentState: meldingState, meldingId })
 
@@ -55,10 +42,11 @@ export const ChangeState = ({ meldingId, meldingState, possibleStates, publicId 
   const t = useTranslations('change-state')
   const tShared = useTranslations('shared')
 
-  const documentTitle = getDocumentTitleOnError({
-    errorMessage: apiError ? t(`errors.${apiError.type}.heading`) : '',
-    hasError: Boolean(apiError),
-    originalDocTitle: t('metadata.title'),
+  // Update document title when there is an API error
+  const documentTitle = useDocumentTitleOnError({
+    apiErrorMessage: apiError ? t(`errors.${apiError.type}.heading`) : undefined,
+    baseDocumentTitle: t('metadata.title'),
+    hasApiError: Boolean(apiError),
   })
 
   useEffect(() => {

--- a/apps/back-office/src/app/melding/[meldingId]/wijzig-urgentie/ChangeUrgency.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/wijzig-urgentie/ChangeUrgency.test.tsx
@@ -23,6 +23,12 @@ const defaultProps: Props = {
 }
 
 describe('ChangeUrgency', () => {
+  it('renders the component with the correct document title', () => {
+    render(<ChangeUrgency {...defaultProps} />)
+
+    expect(document.title).toBe('metadata.title')
+  })
+
   it('renders the backlink', () => {
     render(<ChangeUrgency {...defaultProps} />)
 
@@ -61,7 +67,7 @@ describe('ChangeUrgency', () => {
     expect(screen.getByRole('radio', { name: 'urgency.0' })).toBeChecked()
   })
 
-  it('displays the correct error message and selected urgency when action returns invalid-urgency', () => {
+  it('displays the correct error message, document title and selected urgency when action returns invalid-urgency', () => {
     ;(useActionState as Mock).mockReturnValueOnce([
       { apiError: { type: 'invalid-urgency' }, urgencyFromAction: '1' },
       vi.fn(),
@@ -73,13 +79,19 @@ describe('ChangeUrgency', () => {
     const alert = container.querySelector('.ams-alert')
     const heading = within(alert as HTMLElement).getByRole('heading', { name: 'errors.invalid-urgency.heading' })
 
+    // Alert
     expect(alert).toBeInTheDocument()
     expect(heading).toBeInTheDocument()
     expect(alert).toHaveTextContent('errors.invalid-urgency.description')
+
+    // Doc title
+    expect(document.title).toBe('errors.invalid-urgency.heading - metadata.title')
+
+    // Radio
     expect(screen.getByRole('radio', { name: 'urgency.1' })).toBeChecked()
   })
 
-  it('displays the correct error message and selected urgency when action returns urgency-change-failed', () => {
+  it('displays the correct error message, document title and selected urgency when action returns urgency-change-failed', () => {
     ;(useActionState as Mock).mockReturnValueOnce([
       { apiError: { type: 'urgency-change-failed' }, urgencyFromAction: '-1' },
       vi.fn(),
@@ -91,9 +103,15 @@ describe('ChangeUrgency', () => {
     const alert = container.querySelector('.ams-alert')
     const heading = within(alert as HTMLElement).getByRole('heading', { name: 'errors.urgency-change-failed.heading' })
 
+    // Alert
     expect(alert).toBeInTheDocument()
     expect(heading).toBeInTheDocument()
     expect(alert).toHaveTextContent('errors.urgency-change-failed.description')
+
+    // Doc title
+    expect(document.title).toBe('errors.urgency-change-failed.heading - metadata.title')
+
+    // Radio
     expect(screen.getByRole('radio', { name: 'urgency.-1' })).toBeChecked()
   })
 

--- a/apps/back-office/src/app/melding/[meldingId]/wijzig-urgentie/ChangeUrgency.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/wijzig-urgentie/ChangeUrgency.tsx
@@ -12,6 +12,7 @@ import { BackLink } from '../_components/BackLink'
 import { CancelLink } from '../_components/CancelLink'
 import { postChangeUrgencyForm } from './actions'
 import { ApiErrorAlert } from '~/app/_components'
+import { useDocumentTitleOnError } from '~/app/_utils/useDocumentTitleOnError'
 import { URGENCY_VALUES } from '~/constants'
 
 import styles from './ChangeUrgency.module.css'
@@ -30,18 +31,6 @@ const initialState: {
   urgencyFromAction?: string
 } = {}
 
-type DocumentTitleArgs = {
-  errorMessage: string
-  hasError: boolean
-  originalDocTitle: string
-}
-
-const getDocumentTitleOnError = ({ errorMessage, hasError, originalDocTitle }: DocumentTitleArgs) => {
-  if (hasError) return `${errorMessage} - ${originalDocTitle}`
-
-  return originalDocTitle
-}
-
 export const ChangeUrgency = ({ currentUrgency, meldingId, publicId }: Props) => {
   const postChangeUrgencyFormWithMeldingId = postChangeUrgencyForm.bind(null, {
     currentUrgency,
@@ -56,10 +45,11 @@ export const ChangeUrgency = ({ currentUrgency, meldingId, publicId }: Props) =>
   const t = useTranslations('change-urgency')
   const tShared = useTranslations('shared')
 
-  const documentTitle = getDocumentTitleOnError({
-    errorMessage: apiError ? t(`errors.${apiError.type}.heading`) : '',
-    hasError: Boolean(apiError),
-    originalDocTitle: t('metadata.title'),
+  // Update document title when there is an API error
+  const documentTitle = useDocumentTitleOnError({
+    apiErrorMessage: apiError ? t(`errors.${apiError.type}.heading`) : undefined,
+    baseDocumentTitle: t('metadata.title'),
+    hasApiError: Boolean(apiError),
   })
 
   useEffect(() => {

--- a/apps/back-office/translations/nl.json
+++ b/apps/back-office/translations/nl.json
@@ -203,6 +203,7 @@
     }
   },
   "shared": {
+    "document-title-error-count-prefix": "({count, plural, =1 {1 invoerfout} other {# invoerfouten}})",
     "api-error-alert": {
       "heading": "Er is iets misgegaan",
       "description": "Probeer het later opnieuw."


### PR DESCRIPTION
## What

This adds a `useDocumentTitleOnError` hook, which returns the correct document title when there are API or validation errors. This hook is used in all form pages in the Back Office. 

## Why

Setting the document title on error was missing in some places and done inconsistently in others. This consolidates it in 1 place and uses it consistently. 

Ticket: [SIG-7424](https://gemeente-amsterdam.atlassian.net/browse/SIG-7424)

Before opening a pull request, please ensure your branch is based on `main` and targets `main`.

- [x] Includes AI-assisted code via GitHub Copilot

Check requirements when they are met (strikethrough when not applicable):

- [x] Acknowledges **[team code standards](https://github.com/Amsterdam/meldingen-frontend/tree/main/docs)**
- [x] Has **unit tests** with 100% coverage (if feasible) and all test should pass
- [ ] ~~Has **error handling** and **loading states**~~
- [x] Is **responsive and respects WCAG**
- [ ] ~~**Documentation** has been updated~~
- [x] **Required PR checks** have passed

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-7424]: https://gemeente-amsterdam.atlassian.net/browse/SIG-7424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ