### PR TITLE
Remove underline from rich text editor and rendering

### DIFF
--- a/apps/back-office/package.json
+++ b/apps/back-office/package.json
@@ -26,7 +26,6 @@
     "@tiptap/extension-list": "3.27.4",
     "@tiptap/extension-paragraph": "3.27.4",
     "@tiptap/extension-text": "3.27.4",
-    "@tiptap/extension-underline": "3.27.4",
     "@tiptap/extensions": "3.27.4",
     "@tiptap/markdown": "3.27.4",
     "@tiptap/pm": "3.27.4",

--- a/apps/back-office/src/app/_components/RichTextEditor/Toolbar.test.tsx
+++ b/apps/back-office/src/app/_components/RichTextEditor/Toolbar.test.tsx
@@ -36,7 +36,6 @@ describe('Toolbar', () => {
     expect(toolbar).toHaveAttribute('aria-controls', 'editor')
     expect(screen.getByRole('button', { name: 'bold' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'italic' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'underline' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'unordered-list' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'undo' })).toBeInTheDocument()
   })
@@ -46,7 +45,6 @@ describe('Toolbar', () => {
 
     expect(screen.getByRole('button', { name: 'bold' })).toHaveAttribute('tabindex', '0')
     expect(screen.getByRole('button', { name: 'italic' })).toHaveAttribute('tabindex', '-1')
-    expect(screen.getByRole('button', { name: 'underline' })).toHaveAttribute('tabindex', '-1')
     expect(screen.getByRole('button', { name: 'unordered-list' })).toHaveAttribute('tabindex', '-1')
     expect(screen.getByRole('button', { name: 'undo' })).toHaveAttribute('tabindex', '-1')
   })
@@ -82,7 +80,6 @@ describe('Toolbar', () => {
 
     expect(screen.getByRole('button', { name: 'bold' })).toHaveAttribute('aria-pressed', 'false')
     expect(screen.getByRole('button', { name: 'italic' })).toHaveAttribute('aria-pressed', 'false')
-    expect(screen.getByRole('button', { name: 'underline' })).toHaveAttribute('aria-pressed', 'false')
     expect(screen.getByRole('button', { name: 'unordered-list' })).toHaveAttribute('aria-pressed', 'false')
     expect(screen.getByRole('button', { name: 'undo' })).toHaveAttribute('aria-disabled', 'true')
   })
@@ -110,18 +107,6 @@ describe('Toolbar', () => {
 
     expect(editor.isActive('italic')).toBe(true)
     expect(screen.getByRole('button', { name: 'italic' })).toHaveAttribute('aria-pressed', 'true')
-  })
-
-  it('toggles underline on the selection when the underline button is clicked', async () => {
-    const user = userEvent.setup()
-    const editor = await renderToolbar()
-
-    editor.commands.selectAll()
-
-    await user.click(screen.getByRole('button', { name: 'underline' }))
-
-    expect(editor.isActive('underline')).toBe(true)
-    expect(screen.getByRole('button', { name: 'underline' })).toHaveAttribute('aria-pressed', 'true')
   })
 
   it('toggles a bullet list on the selection when the unordered list button is clicked', async () => {
@@ -180,7 +165,6 @@ describe('Toolbar', () => {
 
     expect(screen.getByRole('button', { name: 'bold' })).toHaveAttribute('aria-pressed', 'false')
     expect(screen.getByRole('button', { name: 'italic' })).toHaveAttribute('aria-pressed', 'false')
-    expect(screen.getByRole('button', { name: 'underline' })).toHaveAttribute('aria-pressed', 'false')
     expect(screen.getByRole('button', { name: 'unordered-list' })).toHaveAttribute('aria-pressed', 'false')
     expect(screen.getByRole('button', { name: 'undo' })).toHaveAttribute('aria-disabled', 'true')
   })

--- a/apps/back-office/src/app/_components/RichTextEditor/Toolbar.tsx
+++ b/apps/back-office/src/app/_components/RichTextEditor/Toolbar.tsx
@@ -2,7 +2,7 @@ import type { Editor, EditorStateSnapshot } from '@tiptap/react'
 import type { RefObject } from 'react'
 
 import { IconButton } from '@amsterdam/design-system-react'
-import { FormattingBoldIcon, FormattingItalicIcon, FormattingUnderlineIcon } from '@amsterdam/design-system-react-icons'
+import { FormattingBoldIcon, FormattingItalicIcon } from '@amsterdam/design-system-react-icons'
 import { useEditorState } from '@tiptap/react'
 import { useTranslations } from 'next-intl'
 import { useRef, useState } from 'react'
@@ -19,7 +19,6 @@ const toolbarStateSelector = (ctx: EditorStateSnapshot<Editor>) => {
     isBold: ctx.editor.isActive('bold') ?? false,
     isBulletList: ctx.editor.isActive('bulletList') ?? false,
     isItalic: ctx.editor.isActive('italic') ?? false,
-    isUnderline: ctx.editor.isActive('underline') ?? false,
   }
 }
 
@@ -28,7 +27,7 @@ type Props = {
   id: string
 }
 
-type ToolbarButton = 'bold' | 'bulletList' | 'italic' | 'underline' | 'undo'
+type ToolbarButton = 'bold' | 'bulletList' | 'italic' | 'undo'
 
 export const Toolbar = ({ editor, id }: Props) => {
   const t = useTranslations('shared.rich-text-editor')
@@ -72,15 +71,6 @@ export const Toolbar = ({ editor, id }: Props) => {
         onFocus={() => setActiveButton('italic')}
         svg={FormattingItalicIcon}
         tabIndex={getTabIndex('italic')}
-      />
-      <IconButton
-        aria-pressed={editorState.isUnderline}
-        className={styles.button}
-        label={t('underline')}
-        onClick={() => editor.chain().focus().toggleUnderline().run()}
-        onFocus={() => setActiveButton('underline')}
-        svg={FormattingUnderlineIcon}
-        tabIndex={getTabIndex('underline')}
       />
       <IconButton
         aria-pressed={editorState.isBulletList}

--- a/apps/back-office/src/app/_utils/parseNoteDocument.test.ts
+++ b/apps/back-office/src/app/_utils/parseNoteDocument.test.ts
@@ -38,8 +38,7 @@ describe('parseNoteDocument', () => {
           { text: '   ', type: 'text' }, // Regular whitespace
           { marks: [{ type: 'bold' }], text: '   ', type: 'text' }, // Bold whitespace
           { marks: [{ type: 'italic' }], text: '   ', type: 'text' }, // Italic whitespace
-          { marks: [{ type: 'underline' }], text: '   ', type: 'text' }, // Underlined whitespace
-          { marks: [{ type: 'bold' }, { type: 'italic' }, { type: 'underline' }], text: '   ', type: 'text' }, // Bold, italic, and underlined whitespace
+          { marks: [{ type: 'bold' }, { type: 'italic' }], text: '   ', type: 'text' }, // Bold and italic whitespace
         ],
         type: 'paragraph',
       },

--- a/apps/back-office/src/app/_utils/parseNoteDocument.test.ts
+++ b/apps/back-office/src/app/_utils/parseNoteDocument.test.ts
@@ -47,7 +47,7 @@ describe('parseNoteDocument', () => {
 
     const result = parseNoteDocument(value)
 
-    expect(result.characterCount).toBe(15)
+    expect(result.characterCount).toBe(12)
     expect(result.isEmpty).toBe(true)
   })
 

--- a/apps/back-office/src/app/_utils/richTextExtensions.ts
+++ b/apps/back-office/src/app/_utils/richTextExtensions.ts
@@ -5,7 +5,6 @@ import { Italic } from '@tiptap/extension-italic'
 import { BulletList, ListItem } from '@tiptap/extension-list'
 import { Paragraph } from '@tiptap/extension-paragraph'
 import { Text } from '@tiptap/extension-text'
-import { Underline } from '@tiptap/extension-underline'
 import { Markdown } from '@tiptap/markdown'
 
 // We don't allow headings in notes, but if a user types '# Heading' in the editor,
@@ -27,7 +26,6 @@ export const richTextExtensions = [
   Text,
   Bold,
   Italic,
-  Underline,
   Markdown,
   HeadingAsText,
   BulletList.configure({ HTMLAttributes: { class: 'ams-unordered-list' } }),

--- a/apps/back-office/src/app/melding/[meldingId]/notities/[noteId]/wijzigen/actions.test.ts
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/[noteId]/wijzigen/actions.test.ts
@@ -80,9 +80,7 @@ describe('postUpdateNoteForm', () => {
     const markedUpWhitespace = JSON.stringify({
       content: [
         {
-          content: [
-            { marks: [{ type: 'bold' }, { type: 'italic' }, { type: 'underline' }], text: '   ', type: 'text' },
-          ],
+          content: [{ marks: [{ type: 'bold' }, { type: 'italic' }], text: '   ', type: 'text' }],
           type: 'paragraph',
         },
       ],

--- a/apps/back-office/src/app/melding/[meldingId]/notities/_components/TipTapMarkdownToHtml.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/_components/TipTapMarkdownToHtml.test.tsx
@@ -20,12 +20,11 @@ describe('TipTapMarkdownToHtml', () => {
     expect(paragraph).toHaveClass('ams-paragraph')
   })
 
-  it('renders bold, italic, and underlined text with their respective tags', () => {
-    render(<TipTapMarkdownToHtml markdown={'**Bold** *Italic* ++Underline++'} />)
+  it('renders bold, and italic text with their respective tags', () => {
+    render(<TipTapMarkdownToHtml markdown={'**Bold** *Italic*'} />)
 
     expect(screen.getByRole('strong')).toHaveTextContent('Bold')
     expect(screen.getByRole('emphasis')).toHaveTextContent('Italic')
-    expect(screen.getByText('Underline').tagName).toBe('U')
   })
 
   it('renders a bullet list as <ul> with <li> items', () => {

--- a/apps/back-office/src/app/melding/[meldingId]/notities/_components/TipTapMarkdownToHtml.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/notities/_components/TipTapMarkdownToHtml.test.tsx
@@ -20,7 +20,7 @@ describe('TipTapMarkdownToHtml', () => {
     expect(paragraph).toHaveClass('ams-paragraph')
   })
 
-  it('renders bold, and italic text with their respective tags', () => {
+  it('renders bold and italic text with their respective tags', () => {
     render(<TipTapMarkdownToHtml markdown={'**Bold** *Italic*'} />)
 
     expect(screen.getByRole('strong')).toHaveTextContent('Bold')

--- a/apps/back-office/translations/nl.json
+++ b/apps/back-office/translations/nl.json
@@ -217,7 +217,6 @@
       "bold": "Vetgedrukt",
       "italic": "Schuingedrukt",
       "toolbar": "Tekst opmaken",
-      "underline": "Onderstreept",
       "unordered-list": "Opsomming",
       "undo": "Ongedaan maken"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,9 +245,6 @@ importers:
       '@tiptap/extension-text':
         specifier: 3.27.4
         version: 3.27.4(@tiptap/core@3.27.4(@tiptap/pm@3.27.4))
-      '@tiptap/extension-underline':
-        specifier: 3.27.4
-        version: 3.27.4(@tiptap/core@3.27.4(@tiptap/pm@3.27.4))
       '@tiptap/extensions':
         specifier: 3.27.4
         version: 3.27.4(@tiptap/core@3.27.4(@tiptap/pm@3.27.4))(@tiptap/pm@3.27.4)
@@ -1803,11 +1800,6 @@ packages:
 
   '@tiptap/extension-text@3.27.4':
     resolution: {integrity: sha512-lKQH/hP4FBXsziHypd6Ywj8JFvMLM5GVkK1xsH6yApNuXbHq95rd42ZOYWpYILIBib7tlaz93z61d74UrJiuiw==}
-    peerDependencies:
-      '@tiptap/core': 3.27.4
-
-  '@tiptap/extension-underline@3.27.4':
-    resolution: {integrity: sha512-nRJGvRyEXDtINlHTW+C2oWcL3vmX1URVxAPpkD3Zwn5Rb/vEeOU/pk/w97I0iid816MR4iVbvl1XhbUVegK9gQ==}
     peerDependencies:
       '@tiptap/core': 3.27.4
 
@@ -6554,10 +6546,6 @@ snapshots:
       '@tiptap/core': 3.27.4(@tiptap/pm@3.27.4)
 
   '@tiptap/extension-text@3.27.4(@tiptap/core@3.27.4(@tiptap/pm@3.27.4))':
-    dependencies:
-      '@tiptap/core': 3.27.4(@tiptap/pm@3.27.4)
-
-  '@tiptap/extension-underline@3.27.4(@tiptap/core@3.27.4(@tiptap/pm@3.27.4))':
     dependencies:
       '@tiptap/core': 3.27.4(@tiptap/pm@3.27.4)
 


### PR DESCRIPTION
## What

This removes the option for underlining from our rich text editor. It's not rendered anymore either.

## Why

Underlined text has some issues:

- Visually, it looks like a link, especially for colorblind people who do not see the difference between black and blue text. 
- Semantically, the TipTap editor and renderer uses a `<u>` tag for underlines. [This tag is meant for 'unarticulated annotation'](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/u), which is not what underlining is. We could use a different tag for this, but there isn't really any tag that communicates 'this text is underlined'.

Seeing as it's not really necessary, removing it seems like the best option. 

Before opening a pull request, please ensure your branch is based on `main` and targets `main`.

- [ ] Includes AI-assisted code via GitHub Copilot

Check requirements when they are met (strikethrough when not applicable):

- [x] Acknowledges **[team code standards](https://github.com/Amsterdam/meldingen-frontend/tree/main/docs)**
- [x] Has **unit tests** with 100% coverage (if feasible) and all test should pass
- [ ] ~~Has **error handling** and **loading states**~~
- [ ] ~~Is **responsive and respects WCAG**~~
- [ ] ~~**Documentation** has been updated~~
- [x] **Required PR checks** have passed

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
