### PR TITLE
Align the attachment POST url to BE update

### DIFF
--- a/apps/melding-form/src/app/(general)/bijlage/Attachments.tsx
+++ b/apps/melding-form/src/app/(general)/bijlage/Attachments.tsx
@@ -143,7 +143,7 @@ export const Attachments = ({ files, formData, meldingId, token }: Props) => {
 
       xhr.open(
         'POST',
-        `${process.env.NEXT_PUBLIC_BACKEND_BASE_URL}/melding/${meldingId}/attachment?token=${encodeURIComponent(token)}`,
+        `${process.env.NEXT_PUBLIC_BACKEND_BASE_URL}/melding/${meldingId}/attachment/melder?token=${encodeURIComponent(token)}`,
       )
 
       startUpload(xhr, upload, setFileUploads)

--- a/apps/melding-form/src/mocks/endpoints.ts
+++ b/apps/melding-form/src/mocks/endpoints.ts
@@ -22,7 +22,7 @@ export const ENDPOINTS = {
 
   POST_MELDING: '/melding',
   POST_MELDING_BY_MELDING_ID_ASSET: '/melding/:id/asset',
-  POST_MELDING_BY_MELDING_ID_ATTACHMENT: '/melding/:id/attachment',
+  POST_MELDING_BY_MELDING_ID_ATTACHMENT_MELDER: '/melding/:id/attachment/melder',
   POST_MELDING_BY_MELDING_ID_QUESTION_BY_QUESTION_ID: '/melding/:melding_id/question/:question_id',
 
   PUT_MELDING_BY_MELDING_ID_ADD_ATTACHMENTS: '/melding/:id/add_attachments',

--- a/apps/melding-form/src/mocks/handlers.ts
+++ b/apps/melding-form/src/mocks/handlers.ts
@@ -61,7 +61,7 @@ export const handlers = [
       token: 'test-token',
     }),
   ),
-  http.post(ENDPOINTS.POST_MELDING_BY_MELDING_ID_ATTACHMENT, () => HttpResponse.json({ id: 42 })),
+  http.post(ENDPOINTS.POST_MELDING_BY_MELDING_ID_ATTACHMENT_MELDER, () => HttpResponse.json({ id: 42 })),
   http.post(ENDPOINTS.POST_MELDING_BY_MELDING_ID_ASSET, () => HttpResponse.json()),
   http.post(ENDPOINTS.POST_MELDING_BY_MELDING_ID_QUESTION_BY_QUESTION_ID, async ({ request }) =>
     // Echo back the request body as the response to make it easier to test if the correct body is sent in the request


### PR DESCRIPTION
## What

Update the `POST: Melding:Attachment Melder` call/url references to align to the BE changes.​ 


## Why

This correct the FE to use the update endpoints for `Melding:Attachment Melder`​

---

Before opening a pull request, please ensure your branch is based on `main` and targets `main`.

- [ ] Includes AI-assisted code via GitHub Copilot

Check requirements when they are met (strikethrough when not applicable):

- [ ] Acknowledges **[team code standards](https://github.com/Amsterdam/meldingen-frontend/tree/main/docs)**
- [ ] Has **unit tests** with 100% coverage (if feasible) and all test should pass
- [ ] Has **error handling** and **loading states**
- [ ] Is **responsive and respects WCAG**
- [ ] **Documentation** has been updated
- [ ] **Required PR checks** have passed

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
