### PR TITLE
Corrects date not showing for additional questions in back-office

### DIFF
--- a/apps/back-office/src/app/melding/[meldingId]/_utils/getAdditionalQuestionsData.test.ts
+++ b/apps/back-office/src/app/melding/[meldingId]/_utils/getAdditionalQuestionsData.test.ts
@@ -1,7 +1,12 @@
 import { http, HttpResponse } from 'msw'
 
 import { getAdditionalQuestionsData } from './getAdditionalQuestionsData'
-import { additionalQuestions, additionalTimeQuestion, additionalValueLabelQuestion } from '~/mocks/data'
+import {
+  additionalDateQuestion,
+  additionalQuestions,
+  additionalTimeQuestion,
+  additionalValueLabelQuestion,
+} from '~/mocks/data'
 import { ENDPOINTS } from '~/mocks/endpoints'
 import { server } from '~/mocks/node'
 
@@ -56,6 +61,22 @@ describe('getAdditionalQuestionsData', () => {
           description: 'Weet ik niet',
           key: additionalTimeQuestionWithNullTime.question.id.toString(),
           term: additionalTimeQuestionWithNullTime.question.text,
+        },
+      ],
+    })
+  })
+
+  it('returns correct additional date question data', async () => {
+    server.use(http.get(ENDPOINTS.GET_MELDING_BY_MELDING_ID_ANSWERS, () => HttpResponse.json([additionalDateQuestion])))
+
+    const result = await getAdditionalQuestionsData(mockMeldingId)
+
+    expect(result).toEqual({
+      data: [
+        {
+          description: additionalDateQuestion.date.converted_date,
+          key: additionalDateQuestion.question.id.toString(),
+          term: additionalDateQuestion.question.text,
         },
       ],
     })

--- a/apps/back-office/src/app/melding/[meldingId]/_utils/getAdditionalQuestionsData.ts
+++ b/apps/back-office/src/app/melding/[meldingId]/_utils/getAdditionalQuestionsData.ts
@@ -3,8 +3,10 @@ import type { GetMeldingByMeldingIdAnswersMelderResponses, ValueLabelObject } fr
 import { getMeldingByMeldingIdAnswers } from '~/app/_api-client/proxy'
 import { handleApiError } from '~/app/_utils/handleApiError'
 
-const getDescription = (answer: GetMeldingByMeldingIdAnswersMelderResponses['200'][number]) => {
+const getDescription = (answer: GetMeldingByMeldingIdAnswersMelderResponses['200'][number]): string => {
   switch (answer.type) {
+    case 'date':
+      return answer.date.converted_date ?? answer.date.label
     case 'text':
       return answer.text
     case 'time':

--- a/apps/back-office/src/app/melding/[meldingId]/_utils/getAdditionalQuestionsData.ts
+++ b/apps/back-office/src/app/melding/[meldingId]/_utils/getAdditionalQuestionsData.ts
@@ -17,8 +17,10 @@ const getDescription = (answer: GetMeldingByMeldingIdAnswersMelderResponses['200
       return answer.time
     case 'value_label':
       return answer.values_and_labels.map((option: ValueLabelObject) => option.label).join(', ')
-    default:
+    default: {
+      const _exhaustive: never = answer
       return ''
+    }
   }
 }
 

--- a/apps/back-office/src/app/melding/[meldingId]/_utils/getAdditionalQuestionsData.ts
+++ b/apps/back-office/src/app/melding/[meldingId]/_utils/getAdditionalQuestionsData.ts
@@ -6,7 +6,8 @@ import { handleApiError } from '~/app/_utils/handleApiError'
 const getDescription = (answer: GetMeldingByMeldingIdAnswersMelderResponses['200'][number]) => {
   switch (answer.type) {
     case 'date':
-      // If converted date is null, it means the melder selected "weet ik niet" for a question about time as 'Weet ik niet"
+      // If converted date is null, it means the melder selected "Weet ik niet" for a date question
+      // In that case, we want to show the 'do not know' label ("Weet ik niet") instead of an empty string.
       // This also catches in the edgecase that converted_date cannot be returned, the label which is formatted as "gisteren augustus 5"
       return answer.date.converted_date ?? answer.date.label
     case 'text':

--- a/apps/back-office/src/app/melding/[meldingId]/_utils/getAdditionalQuestionsData.ts
+++ b/apps/back-office/src/app/melding/[meldingId]/_utils/getAdditionalQuestionsData.ts
@@ -3,9 +3,11 @@ import type { GetMeldingByMeldingIdAnswersMelderResponses, ValueLabelObject } fr
 import { getMeldingByMeldingIdAnswers } from '~/app/_api-client/proxy'
 import { handleApiError } from '~/app/_utils/handleApiError'
 
-const getDescription = (answer: GetMeldingByMeldingIdAnswersMelderResponses['200'][number]): string => {
+const getDescription = (answer: GetMeldingByMeldingIdAnswersMelderResponses['200'][number]) => {
   switch (answer.type) {
     case 'date':
+      // If converted date is null, it means the melder selected "weet ik niet" for a question about time as 'Weet ik niet"
+      // This also catches in the edgecase that converted_date cannot be returned, the label which is formatted as "gisteren augustus 5"
       return answer.date.converted_date ?? answer.date.label
     case 'text':
       return answer.text

--- a/apps/back-office/src/mocks/data.ts
+++ b/apps/back-office/src/mocks/data.ts
@@ -1,5 +1,6 @@
 import type {
   AssetOutput,
+  DateAnswerQuestionOutput,
   FormTextAreaComponentOutput,
   MeldingOutput,
   TextAnswerQuestionOutput,
@@ -123,6 +124,25 @@ export const additionalQuestions: TextAnswerQuestionOutput[] = [
     updated_at: '2025-02-18T10:34:32.187573',
   },
 ]
+
+export const additionalDateQuestion: DateAnswerQuestionOutput = {
+  created_at: '2026-08-10T10:21:03Z',
+  date: {
+    converted_date: '2026-08-06',
+    label: 'Donderdag 6 augustus',
+    value: 'day - 4',
+  },
+  id: 12,
+  original_question_text: 'Welke dag was het?',
+  question: {
+    created_at: '2026-08-10T10:13:05Z',
+    id: 2,
+    text: 'Welke dag was het?',
+    updated_at: '2026-08-10T10:13:05Z',
+  },
+  type: 'date',
+  updated_at: '2026-08-10T10:21:03Z',
+}
 
 export const additionalTimeQuestion: TimeAnswerQuestionOutput = {
   created_at: '2025-02-18T10:34:32.193123',


### PR DESCRIPTION
## What

- Add support to handle `answer.type` of `date`   
- Includes additional exhaustive check to disallow non-handled types
- Falls back to use `label` if `converted_date` returns `null`

## Why

This PR solves the issue that date type content does not get rendered in the back-office

Ticket: [SIG-7524](https://gemeente-amsterdam.atlassian.net/browse/SIG-7524)

- [ ] Includes AI-assisted code via GitHub Copilot

Check requirements when they are met (strikethrough when not applicable):

- [ ] Acknowledges **[team code standards](https://github.com/Amsterdam/meldingen-frontend/tree/main/docs)**
- [ ] Has **unit tests** with 100% coverage (if feasible) and all test should pass
- [ ] Has **error handling** and **loading states**
- [ ] Is **responsive and respects WCAG**
- [ ] **Documentation** has been updated
- [ ] **Required PR checks** have passed

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-7524]: https://gemeente-amsterdam.atlassian.net/browse/SIG-7524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ