### PR TITLE
Increase zoom level on location selection by changing to RD coordinates

### DIFF
--- a/libs/map/package.json
+++ b/libs/map/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "@meldingen/api-client": "workspace:*",
     "leaflet": "1.9.4",
-    "leaflet.markercluster": "1.5.3"
+    "leaflet.markercluster": "1.5.3",
+    "proj4": "2.21.0"
   },
   "devDependencies": {
     "@types/geojson": "7946.0.16",

--- a/libs/map/src/Map/Map.tsx
+++ b/libs/map/src/Map/Map.tsx
@@ -51,7 +51,7 @@ export const MapComponent = ({ children, hasAlert, isHidden, testMapInstance }: 
       ],
       maxZoom: 16,
       minZoom: 8,
-      zoom: 14,
+      zoom: 9,
       zoomControl: false,
     })
 

--- a/libs/map/src/Map/Map.tsx
+++ b/libs/map/src/Map/Map.tsx
@@ -4,6 +4,8 @@ import { clsx } from 'clsx'
 import { latLng, Map, tileLayer } from 'leaflet'
 import { createContext, useEffect, useRef, useState } from 'react'
 
+import getCrsRd from './utils/getCrsRd'
+
 import 'leaflet/dist/leaflet.css'
 import styles from './Map.module.css'
 
@@ -33,10 +35,12 @@ export const MapComponent = ({ children, hasAlert, isHidden, testMapInstance }: 
 
     const map = new Map(mapRef.current, {
       center: latLng([52.370216, 4.895168]),
+      crs: getCrsRd(),
       layers: [
-        tileLayer('https://{s}.data.amsterdam.nl/topo_wm/{z}/{x}/{y}.png', {
+        tileLayer('https://{s}.data.amsterdam.nl/topo_rd/{z}/{x}/{y}.png', {
           attribution: '',
           subdomains: ['t1', 't2', 't3', 't4'],
+          tms: true,
         }),
       ],
       // Prevent the user browsing too far outside Amsterdam otherwise the map will render blank greyspace.
@@ -45,8 +49,8 @@ export const MapComponent = ({ children, hasAlert, isHidden, testMapInstance }: 
         [52.25168, 4.64034],
         [52.50536, 5.10737],
       ],
-      maxZoom: 18,
-      minZoom: 11,
+      maxZoom: 16,
+      minZoom: 8,
       zoom: 14,
       zoomControl: false,
     })

--- a/libs/map/src/Map/Map.tsx
+++ b/libs/map/src/Map/Map.tsx
@@ -51,7 +51,7 @@ export const MapComponent = ({ children, hasAlert, isHidden, testMapInstance }: 
       ],
       maxZoom: 16,
       minZoom: 8,
-      zoom: 9,
+      zoom: 10,
       zoomControl: false,
     })
 

--- a/libs/map/src/Map/utils/getCrsRd.test.ts
+++ b/libs/map/src/Map/utils/getCrsRd.test.ts
@@ -1,0 +1,59 @@
+import type { Bounds, CRS, Projection } from 'leaflet'
+
+import L from 'leaflet'
+
+import getCrsRd, { CRS_CONFIG } from './getCrsRd'
+
+type RdProjection = Projection & {
+  bounds: Bounds
+  proj4def: string
+}
+
+describe('getCrsRd', () => {
+  it('returns the expected RD CRS configuration', () => {
+    const crs = getCrsRd()
+    const projection = crs.projection as RdProjection
+
+    expect(crs.code).toBe(CRS_CONFIG.RD.code)
+    expect(crs.distance).toBe(L.CRS.Earth.distance)
+    expect(crs.infinite).toBe(false)
+    expect(crs.R).toBe(CRS_CONFIG.EARTH_RADIUS)
+    expect(projection.proj4def).toBe(CRS_CONFIG.RD.projection)
+    expect(projection.bounds.min.x).toBe(CRS_CONFIG.RD.transformation.bounds.topLeft[0])
+    expect(projection.bounds.min.y).toBe(CRS_CONFIG.RD.transformation.bounds.bottomRight[1])
+    expect(projection.bounds.max.x).toBe(CRS_CONFIG.RD.transformation.bounds.bottomRight[0])
+    expect(projection.bounds.max.y).toBe(CRS_CONFIG.RD.transformation.bounds.topLeft[1])
+  })
+
+  it('calculates scales for cached and uncached zoom levels', () => {
+    const zeroScale = 1000
+    const crs = getCrsRd(2, zeroScale)
+
+    expect(crs.scale(0)).toBe(1 / zeroScale)
+    expect(crs.scale(1)).toBe(1 / (zeroScale * 0.5))
+    expect(crs.scale(2)).toBe(1 / (zeroScale * 0.25))
+    expect(crs.scale(3)).toBe(1 / (zeroScale * 0.125))
+  })
+
+  it('uses matching scale and zoom conversions', () => {
+    const crs = getCrsRd()
+    const zoomLevel = 5
+    const scale = crs.scale(zoomLevel)
+
+    expect(crs.zoom(scale)).toBe(zoomLevel)
+  })
+
+  it('projects and unprojects coordinates consistently', () => {
+    const crs = getCrsRd()
+    const projection = crs.projection as CRS['projection']
+    const amsterdam = L.latLng(52.370216, 4.895168)
+
+    const point = projection.project(amsterdam)
+    const roundTrip = projection.unproject(point)
+
+    expect(point.x).toBeCloseTo(121490, 0)
+    expect(point.y).toBeCloseTo(487040, 0)
+    expect(roundTrip.lat).toBeCloseTo(amsterdam.lat, 6)
+    expect(roundTrip.lng).toBeCloseTo(amsterdam.lng, 6)
+  })
+})

--- a/libs/map/src/Map/utils/getCrsRd.test.ts
+++ b/libs/map/src/Map/utils/getCrsRd.test.ts
@@ -1,59 +1,230 @@
-import type { Bounds, CRS, Projection } from 'leaflet'
+import { CRS, latLng, Point, Transformation } from 'leaflet'
+import { describe, expect, it } from 'vitest'
 
-import L from 'leaflet'
+import getCrsRd, { CRS_CONFIG, proj4RD } from './getCrsRd'
 
-import getCrsRd, { CRS_CONFIG } from './getCrsRd'
+describe('CRS_CONFIG', () => {
+  it('has the correct earth radius', () => {
+    expect(CRS_CONFIG.EARTH_RADIUS).toBe(6378137)
+  })
 
-type RdProjection = Projection & {
-  bounds: Bounds
-  proj4def: string
-}
+  it('has the correct RD EPSG code', () => {
+    expect(CRS_CONFIG.RD.code).toBe('EPSG:28992')
+  })
+
+  it('has an RD proj4 definition using the stereographic projection', () => {
+    expect(CRS_CONFIG.RD.projection).toContain('+proj=sterea')
+    expect(CRS_CONFIG.RD.projection).toContain('+lat_0=52.15616055555555')
+    expect(CRS_CONFIG.RD.projection).toContain('+lon_0=5.38763888888889')
+    expect(CRS_CONFIG.RD.projection).toContain('+units=m')
+  })
+
+  it('has the correct RD transformation bounds', () => {
+    expect(CRS_CONFIG.RD.transformation.bounds.topLeft).toEqual([-285401, 903401])
+    expect(CRS_CONFIG.RD.transformation.bounds.bottomRight).toEqual([595401.92, 22598.08])
+  })
+
+  it('has the correct WGS84 code and proj4 definition', () => {
+    expect(CRS_CONFIG.WGS84.code).toBe('EPSG:4326')
+    expect(CRS_CONFIG.WGS84.projection).toBe('+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
+  })
+})
 
 describe('getCrsRd', () => {
-  it('returns the expected RD CRS configuration', () => {
-    const crs = getCrsRd()
-    const projection = crs.projection as RdProjection
+  describe('basic CRS shape', () => {
+    it('uses the configured RD code', () => {
+      const crs = getCrsRd()
+      expect(crs.code).toBe(CRS_CONFIG.RD.code)
+    })
 
-    expect(crs.code).toBe(CRS_CONFIG.RD.code)
-    expect(crs.distance).toBe(L.CRS.Earth.distance)
-    expect(crs.infinite).toBe(false)
-    expect(crs.R).toBe(CRS_CONFIG.EARTH_RADIUS)
-    expect(projection.proj4def).toBe(CRS_CONFIG.RD.projection)
-    expect(projection.bounds.min.x).toBe(CRS_CONFIG.RD.transformation.bounds.topLeft[0])
-    expect(projection.bounds.min.y).toBe(CRS_CONFIG.RD.transformation.bounds.bottomRight[1])
-    expect(projection.bounds.max.x).toBe(CRS_CONFIG.RD.transformation.bounds.bottomRight[0])
-    expect(projection.bounds.max.y).toBe(CRS_CONFIG.RD.transformation.bounds.topLeft[1])
+    it('is not infinite', () => {
+      const crs = getCrsRd()
+      expect(crs.infinite).toBe(false)
+    })
+
+    it('uses CRS.Earth.distance as its distance function', () => {
+      const crs = getCrsRd()
+      expect(crs.distance).toBe(CRS.Earth.distance)
+    })
+
+    it('uses the configured earth radius', () => {
+      const crs = getCrsRd()
+      expect(crs.R).toBe(CRS_CONFIG.EARTH_RADIUS)
+    })
+
+    it('inherits properties from CRS.Simple that are not overridden', () => {
+      const crs = getCrsRd()
+      expect(crs.wrapLng).toBe(CRS.Simple.wrapLng)
+      expect(crs.wrapLat).toBe(CRS.Simple.wrapLat)
+    })
   })
 
-  it('calculates scales for cached and uncached zoom levels', () => {
-    const zeroScale = 1000
-    const crs = getCrsRd(2, zeroScale)
+  describe('transformation', () => {
+    it('creates a Transformation instance with the expected coefficients', () => {
+      const crs = getCrsRd()
+      expect(crs.transformation).toBeInstanceOf(Transformation)
 
-    expect(crs.scale(0)).toBe(1 / zeroScale)
-    expect(crs.scale(1)).toBe(1 / (zeroScale * 0.5))
-    expect(crs.scale(2)).toBe(1 / (zeroScale * 0.25))
-    expect(crs.scale(3)).toBe(1 / (zeroScale * 0.125))
+      // Transformation(1, 285401.92, -1, 903401.92) applied to (0,0) at scale 1
+      // => x' = 1*0 + 285401.92, y' = -1*0 + 903401.92
+      const transformed = crs.transformation.transform(new Point(0, 0), 1)
+      expect(transformed.x).toBeCloseTo(285401.92)
+      expect(transformed.y).toBeCloseTo(903401.92)
+    })
+
+    it('applies the transformation coefficients correctly for a non-zero point', () => {
+      const crs = getCrsRd()
+      const transformed = crs.transformation.transform(new Point(1000, 2000), 1)
+      expect(transformed.x).toBeCloseTo(1 * 1000 + 285401.92)
+      expect(transformed.y).toBeCloseTo(-1 * 2000 + 903401.92)
+    })
   })
 
-  it('uses matching scale and zoom conversions', () => {
-    const crs = getCrsRd()
-    const zoomLevel = 5
-    const scale = crs.scale(zoomLevel)
+  describe('projection bounds', () => {
+    it('normalizes the configured RD bounds into min/max', () => {
+      const crs = getCrsRd()
+      const projBounds = crs.projection.bounds
 
-    expect(crs.zoom(scale)).toBe(zoomLevel)
+      expect(projBounds.min?.x).toBeCloseTo(-285401)
+      expect(projBounds.min?.y).toBeCloseTo(22598.08)
+      expect(projBounds.max?.x).toBeCloseTo(595401.92)
+      expect(projBounds.max?.y).toBeCloseTo(903401)
+    })
+
+    it('exposes the raw proj4 definition on the projection', () => {
+      const crs = getCrsRd()
+      expect(crs.projection.proj4def).toBe(CRS_CONFIG.RD.projection)
+    })
   })
 
-  it('projects and unprojects coordinates consistently', () => {
-    const crs = getCrsRd()
-    const projection = crs.projection as CRS['projection']
-    const amsterdam = L.latLng(52.370216, 4.895168)
+  describe('project / unproject', () => {
+    it('projects a LatLng using proj4RD.forward and returns a Point', () => {
+      const crs = getCrsRd()
+      const ll = latLng(52.0907, 5.1214)
+      const point = crs.projection.project(ll)
 
-    const point = projection.project(amsterdam)
-    const roundTrip = projection.unproject(point)
+      const [expectedX, expectedY] = proj4RD.forward([5.1214, 52.0907])
 
-    expect(point.x).toBeCloseTo(121490, 0)
-    expect(point.y).toBeCloseTo(487040, 0)
-    expect(roundTrip.lat).toBeCloseTo(amsterdam.lat, 6)
-    expect(roundTrip.lng).toBeCloseTo(amsterdam.lng, 6)
+      expect(point).toBeInstanceOf(Point)
+      expect(point.x).toBeCloseTo(expectedX)
+      expect(point.y).toBeCloseTo(expectedY)
+    })
+
+    it('unprojects a Point using proj4RD.inverse and returns a LatLng', () => {
+      const crs = getCrsRd()
+      const point = new Point(136000, 456000)
+      const ll = crs.projection.unproject(point)
+
+      const [expectedLng, expectedLat] = proj4RD.inverse([136000, 456000])
+
+      expect(ll.lat).toBeCloseTo(expectedLat)
+      expect(ll.lng).toBeCloseTo(expectedLng)
+    })
+
+    it('round-trips project -> unproject back to the original LatLng', () => {
+      const crs = getCrsRd()
+      const original = latLng(52.3731, 4.8926)
+
+      const projected = crs.projection.project(original)
+      const back = crs.projection.unproject(projected)
+
+      expect(back.lat).toBeCloseTo(original.lat, 6)
+      expect(back.lng).toBeCloseTo(original.lng, 6)
+    })
+  })
+
+  describe('scale', () => {
+    it('returns the precomputed scale for every zoom level within maxZoom', () => {
+      const crs = getCrsRd(16, 3440.64)
+
+      for (let z = 0; z <= 16; z++) {
+        const expected = 1 / (3440.64 * 0.5 ** z)
+        expect(crs.scale(z)).toBeCloseTo(expected)
+      }
+    })
+
+    it('falls back to the formula for zoom levels beyond the precomputed range', () => {
+      const crs = getCrsRd(5, 3440.64)
+      const expected = 1 / (3440.64 * 0.5 ** 10)
+      expect(crs.scale(10)).toBeCloseTo(expected)
+    })
+
+    it('respects a custom zeroScale', () => {
+      const crs = getCrsRd(4, 1000)
+      expect(crs.scale(0)).toBeCloseTo(1 / 1000)
+      expect(crs.scale(1)).toBeCloseTo(1 / 500)
+      expect(crs.scale(2)).toBeCloseTo(1 / 250)
+    })
+
+    it('scale increases as zoom increases (zooming in makes things bigger)', () => {
+      const crs = getCrsRd()
+      expect(crs.scale(5)).toBeGreaterThan(crs.scale(4))
+      expect(crs.scale(1)).toBeGreaterThan(crs.scale(0))
+    })
+  })
+
+  describe('zoom', () => {
+    it('inverts the scale function for precomputed zoom levels', () => {
+      const crs = getCrsRd()
+      for (let z = 0; z <= 5; z++) {
+        const s = crs.scale(z)
+        expect(crs.zoom(s)).toBeCloseTo(z, 5)
+      }
+    })
+
+    it('computes zoom correctly using the default zeroScale', () => {
+      const crs = getCrsRd()
+      const scale = 1 / (3440.64 * 0.5 ** 3)
+      expect(crs.zoom(scale)).toBeCloseTo(3)
+    })
+
+    it('computes zoom correctly using a custom zeroScale', () => {
+      const crs = getCrsRd(10, 1000)
+      const scale = 1 / (1000 * 0.5 ** 4)
+      expect(crs.zoom(scale)).toBeCloseTo(4)
+    })
+  })
+
+  describe('scales array parameter (mutable default argument behavior)', () => {
+    it('populates a user-supplied empty array with maxZoom + 1 entries', () => {
+      const customScales: number[] = []
+      getCrsRd(2, 3440.64, customScales)
+
+      expect(customScales).toHaveLength(3) // zoom 0, 1, 2
+      expect(customScales[0]).toBeCloseTo(1 / 3440.64)
+      expect(customScales[2]).toBeCloseTo(1 / (3440.64 * 0.5 ** 2))
+    })
+
+    it('appends to (rather than replacing) a pre-populated scales array', () => {
+      // NOTE: this documents a side-effect of the implementation: since
+      // `scales.push(...)` is used without clearing the array first, any
+      // pre-existing entries are preserved and new entries are appended
+      // after them, rather than the array being reset/overwritten.
+      const preExisting = [999]
+      getCrsRd(1, 3440.64, preExisting)
+
+      expect(preExisting[0]).toBe(999)
+      expect(preExisting).toHaveLength(1 + 2) // original entry + zoom 0,1
+      expect(preExisting[1]).toBeCloseTo(1 / 3440.64)
+      expect(preExisting[2]).toBeCloseTo(1 / (3440.64 * 0.5 ** 1))
+    })
+
+    it('does not leak scales between separate calls when no array is passed', () => {
+      const crsA = getCrsRd(2)
+      const crsB = getCrsRd(2)
+
+      expect(crsA.scale(0)).toBeCloseTo(crsB.scale(0))
+      expect(crsA.scale(2)).toBeCloseTo(crsB.scale(2))
+    })
+  })
+
+  describe('default parameters', () => {
+    it('uses maxZoom=16 and zeroScale=3440.64 when called with no arguments', () => {
+      const crs = getCrsRd()
+      expect(crs.scale(0)).toBeCloseTo(1 / 3440.64)
+      expect(crs.scale(16)).toBeCloseTo(1 / (3440.64 * 0.5 ** 16))
+      // zoom 17 is beyond the default precomputed range, so it should
+      // fall back to the formula rather than throwing or returning undefined
+      expect(crs.scale(17)).toBeCloseTo(1 / (3440.64 * 0.5 ** 17))
+    })
   })
 })

--- a/libs/map/src/Map/utils/getCrsRd.test.ts
+++ b/libs/map/src/Map/utils/getCrsRd.test.ts
@@ -184,28 +184,23 @@ describe('getCrsRd', () => {
     })
   })
 
-  describe('scales array parameter (mutable default argument behavior)', () => {
-    it('populates a user-supplied empty array with maxZoom + 1 entries', () => {
+  describe('scales array parameter', () => {
+    it('does not mutate a user-supplied empty array', () => {
       const customScales: number[] = []
-      getCrsRd(2, 3440.64, customScales)
+      const crs = getCrsRd(2, 3440.64, customScales)
 
-      expect(customScales).toHaveLength(3) // zoom 0, 1, 2
-      expect(customScales[0]).toBeCloseTo(1 / 3440.64)
-      expect(customScales[2]).toBeCloseTo(1 / (3440.64 * 0.5 ** 2))
+      expect(customScales).toEqual([])
+      expect(crs.scale(0)).toBeCloseTo(1 / 3440.64)
+      expect(crs.scale(2)).toBeCloseTo(1 / (3440.64 * 0.5 ** 2))
     })
 
-    it('appends to (rather than replacing) a pre-populated scales array', () => {
-      // NOTE: this documents a side-effect of the implementation: since
-      // `scales.push(...)` is used without clearing the array first, any
-      // pre-existing entries are preserved and new entries are appended
-      // after them, rather than the array being reset/overwritten.
+    it('does not overwrite a pre-populated caller-owned scales array', () => {
       const preExisting = [999]
-      getCrsRd(1, 3440.64, preExisting)
+      const crs = getCrsRd(1, 3440.64, preExisting)
 
-      expect(preExisting[0]).toBe(999)
-      expect(preExisting).toHaveLength(1 + 2) // original entry + zoom 0,1
-      expect(preExisting[1]).toBeCloseTo(1 / 3440.64)
-      expect(preExisting[2]).toBeCloseTo(1 / (3440.64 * 0.5 ** 1))
+      expect(preExisting).toEqual([999])
+      expect(crs.scale(0)).toBeCloseTo(1 / 3440.64)
+      expect(crs.scale(1)).toBeCloseTo(1 / (3440.64 * 0.5 ** 1))
     })
 
     it('does not leak scales between separate calls when no array is passed', () => {

--- a/libs/map/src/Map/utils/getCrsRd.test.ts
+++ b/libs/map/src/Map/utils/getCrsRd.test.ts
@@ -3,55 +3,8 @@ import { describe, expect, it } from 'vitest'
 
 import getCrsRd, { CRS_CONFIG, proj4RD } from './getCrsRd'
 
-describe('CRS_CONFIG', () => {
-  it('has the correct earth radius', () => {
-    expect(CRS_CONFIG.EARTH_RADIUS).toBe(6378137)
-  })
-
-  it('has the correct RD EPSG code', () => {
-    expect(CRS_CONFIG.RD.code).toBe('EPSG:28992')
-  })
-
-  it('has an RD proj4 definition using the stereographic projection', () => {
-    expect(CRS_CONFIG.RD.projection).toContain('+proj=sterea')
-    expect(CRS_CONFIG.RD.projection).toContain('+lat_0=52.15616055555555')
-    expect(CRS_CONFIG.RD.projection).toContain('+lon_0=5.38763888888889')
-    expect(CRS_CONFIG.RD.projection).toContain('+units=m')
-  })
-
-  it('has the correct RD transformation bounds', () => {
-    expect(CRS_CONFIG.RD.transformation.bounds.topLeft).toEqual([-285401, 903401])
-    expect(CRS_CONFIG.RD.transformation.bounds.bottomRight).toEqual([595401.92, 22598.08])
-  })
-
-  it('has the correct WGS84 code and proj4 definition', () => {
-    expect(CRS_CONFIG.WGS84.code).toBe('EPSG:4326')
-    expect(CRS_CONFIG.WGS84.projection).toBe('+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
-  })
-})
-
 describe('getCrsRd', () => {
   describe('basic CRS shape', () => {
-    it('uses the configured RD code', () => {
-      const crs = getCrsRd()
-      expect(crs.code).toBe(CRS_CONFIG.RD.code)
-    })
-
-    it('is not infinite', () => {
-      const crs = getCrsRd()
-      expect(crs.infinite).toBe(false)
-    })
-
-    it('uses CRS.Earth.distance as its distance function', () => {
-      const crs = getCrsRd()
-      expect(crs.distance).toBe(CRS.Earth.distance)
-    })
-
-    it('uses the configured earth radius', () => {
-      const crs = getCrsRd()
-      expect(crs.R).toBe(CRS_CONFIG.EARTH_RADIUS)
-    })
-
     it('inherits properties from CRS.Simple that are not overridden', () => {
       const crs = getCrsRd()
       expect(crs.wrapLng).toBe(CRS.Simple.wrapLng)

--- a/libs/map/src/Map/utils/getCrsRd.ts
+++ b/libs/map/src/Map/utils/getCrsRd.ts
@@ -1,8 +1,7 @@
-import type { CRS, LatLng } from 'leaflet'
-import type { PointExpression } from 'leaflet'
+import type { LatLng, PointExpression } from 'leaflet'
 import type { InterfaceCoordinates } from 'proj4'
 
-import L from 'leaflet'
+import { bounds, CRS, latLng, Point, Transformation } from 'leaflet'
 import proj4 from 'proj4'
 
 export const CRS_CONFIG = {
@@ -38,28 +37,28 @@ export const proj4RD = proj4(CRS_CONFIG.WGS84.code, CRS_CONFIG.RD.projection)
  * @param zeroScale
  * @param scales
  */
-const getCrsRd = (maxZoom = 16, zeroScale = 3440.64, scales: number[] = []): CRS => {
+const getCrsRd = (maxZoom = 16, zeroScale = 3440.64, scales: number[] = []) => {
   for (let i = 0; i <= maxZoom; i++) {
     scales.push(1 / (zeroScale * 0.5 ** i))
   }
 
   return {
-    ...L.CRS.Simple,
+    ...CRS.Simple,
     ...{
       code: CRS_CONFIG.RD.code,
-      distance: L.CRS.Earth.distance,
+      distance: CRS.Earth.distance,
       infinite: false,
       projection: {
-        bounds: L.bounds(CRS_CONFIG.RD.transformation.bounds.topLeft, CRS_CONFIG.RD.transformation.bounds.bottomRight),
+        bounds: bounds(CRS_CONFIG.RD.transformation.bounds.topLeft, CRS_CONFIG.RD.transformation.bounds.bottomRight),
         proj4def: CRS_CONFIG.RD.projection,
         project: (latlng: LatLng) => {
           const [x, y] = proj4RD.forward([latlng.lng, latlng.lat])
-          return new L.Point(x, y)
+          return new Point(x, y)
         },
 
         unproject: (point: InterfaceCoordinates) => {
           const [lng, lat] = proj4RD.inverse([point.x, point.y])
-          return L.latLng(lat, lng)
+          return latLng(lat, lng)
         },
       },
 
@@ -70,7 +69,7 @@ const getCrsRd = (maxZoom = 16, zeroScale = 3440.64, scales: number[] = []): CRS
         }
         return 1 / (zeroScale * 0.5 ** zoom)
       },
-      transformation: new L.Transformation(1, 285401.92, -1, 903401.92),
+      transformation: new Transformation(1, 285401.92, -1, 903401.92),
 
       zoom: (scale: number) => Math.log(1 / scale / zeroScale) / Math.log(0.5),
     },

--- a/libs/map/src/Map/utils/getCrsRd.ts
+++ b/libs/map/src/Map/utils/getCrsRd.ts
@@ -1,0 +1,80 @@
+import type { CRS, LatLng } from 'leaflet'
+import type { PointExpression } from 'leaflet'
+import type { InterfaceCoordinates } from 'proj4'
+
+import L from 'leaflet'
+import proj4 from 'proj4'
+
+export const CRS_CONFIG = {
+  EARTH_RADIUS: 6378137,
+  RD: {
+    code: 'EPSG:28992',
+    projection:
+      '+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.9999079 +x_0=155000 +' +
+      'y_0=463000 +ellps=bessel +units=m +towgs84=565.2369,50.0087,465.658,-0.406857330322398,0.3507326' +
+      '76542563,-1.8703473836068,4.0812 +no_defs',
+    transformation: {
+      bounds: {
+        bottomRight: [595401.92, 22598.08] as PointExpression,
+        topLeft: [-285401, 903401] as PointExpression,
+      },
+    },
+  },
+  WGS84: {
+    code: 'EPSG:4326',
+    projection: '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs',
+  },
+}
+
+export const proj4RD = proj4(CRS_CONFIG.WGS84.code, CRS_CONFIG.RD.projection)
+
+/**
+ * Returns RD coordinates (RD = "Rijksdriehoekscoordinaten") in the
+ * geodetic coordinate system used nationally in the European Netherlands
+ * for geographical indications and files.
+ * CRS means coordinate reference system, describing coordinate meaning.
+ *
+ * @param maxZoom
+ * @param zeroScale
+ * @param scales
+ */
+const getCrsRd = (maxZoom = 16, zeroScale = 3440.64, scales: number[] = []): CRS => {
+  for (let i = 0; i <= maxZoom; i++) {
+    scales.push(1 / (zeroScale * 0.5 ** i))
+  }
+
+  return {
+    ...L.CRS.Simple,
+    ...{
+      code: CRS_CONFIG.RD.code,
+      distance: L.CRS.Earth.distance,
+      infinite: false,
+      projection: {
+        bounds: L.bounds(CRS_CONFIG.RD.transformation.bounds.topLeft, CRS_CONFIG.RD.transformation.bounds.bottomRight),
+        proj4def: CRS_CONFIG.RD.projection,
+        project: (latlng: LatLng) => {
+          const [x, y] = proj4RD.forward([latlng.lng, latlng.lat])
+          return new L.Point(x, y)
+        },
+
+        unproject: (point: InterfaceCoordinates) => {
+          const [lng, lat] = proj4RD.inverse([point.x, point.y])
+          return L.latLng(lat, lng)
+        },
+      },
+
+      R: CRS_CONFIG.EARTH_RADIUS,
+      scale: (zoom: number) => {
+        if (scales[zoom]) {
+          return scales[zoom]
+        }
+        return 1 / (zeroScale * 0.5 ** zoom)
+      },
+      transformation: new L.Transformation(1, 285401.92, -1, 903401.92),
+
+      zoom: (scale: number) => Math.log(1 / scale / zeroScale) / Math.log(0.5),
+    },
+  }
+}
+
+export default getCrsRd

--- a/libs/map/src/Map/utils/getCrsRd.ts
+++ b/libs/map/src/Map/utils/getCrsRd.ts
@@ -38,8 +38,10 @@ export const proj4RD = proj4(CRS_CONFIG.WGS84.code, CRS_CONFIG.RD.projection)
  * @param scales
  */
 const getCrsRd = (maxZoom = 16, zeroScale = 3440.64, scales: number[] = []) => {
+  const precomputedScales = [...scales]
+
   for (let i = 0; i <= maxZoom; i++) {
-    scales.push(1 / (zeroScale * 0.5 ** i))
+    precomputedScales[i] = 1 / (zeroScale * 0.5 ** i)
   }
 
   return {
@@ -64,8 +66,8 @@ const getCrsRd = (maxZoom = 16, zeroScale = 3440.64, scales: number[] = []) => {
 
       R: CRS_CONFIG.EARTH_RADIUS,
       scale: (zoom: number) => {
-        if (scales[zoom]) {
-          return scales[zoom]
+        if (precomputedScales[zoom]) {
+          return precomputedScales[zoom]
         }
         return 1 / (zeroScale * 0.5 ** zoom)
       },

--- a/libs/map/src/MarkerSelectLayer/MarkerSelectLayer.tsx
+++ b/libs/map/src/MarkerSelectLayer/MarkerSelectLayer.tsx
@@ -17,7 +17,7 @@ import { getWfsFilter } from './utils/getWfsFilter'
 
 import './cluster.css'
 
-export const ZOOM_THRESHOLD = 8
+export const ZOOM_THRESHOLD = 11
 
 export type WfsQuery = {
   assetTypeId?: number

--- a/libs/map/src/MarkerSelectLayer/MarkerSelectLayer.tsx
+++ b/libs/map/src/MarkerSelectLayer/MarkerSelectLayer.tsx
@@ -17,7 +17,7 @@ import { getWfsFilter } from './utils/getWfsFilter'
 
 import './cluster.css'
 
-export const ZOOM_THRESHOLD = 16
+export const ZOOM_THRESHOLD = 8
 
 export type WfsQuery = {
   assetTypeId?: number

--- a/libs/map/src/PointSelectLayer/PointSelectLayer.tsx
+++ b/libs/map/src/PointSelectLayer/PointSelectLayer.tsx
@@ -8,7 +8,7 @@ import type { Coordinates } from '../types'
 import { MapContext } from '../Map/Map'
 import { Crosshair } from './Crosshair'
 
-export const FLY_TO_MIN_ZOOM = 8
+export const FLY_TO_MIN_ZOOM = 13
 
 const defaultIcon = icon({
   iconAnchor: [15, 40],

--- a/libs/map/src/PointSelectLayer/PointSelectLayer.tsx
+++ b/libs/map/src/PointSelectLayer/PointSelectLayer.tsx
@@ -8,7 +8,7 @@ import type { Coordinates } from '../types'
 import { MapContext } from '../Map/Map'
 import { Crosshair } from './Crosshair'
 
-export const FLY_TO_MIN_ZOOM = 18
+export const FLY_TO_MIN_ZOOM = 8
 
 const defaultIcon = icon({
   iconAnchor: [15, 40],

--- a/libs/map/src/PointSelectLayer/PointSelectLayer.tsx
+++ b/libs/map/src/PointSelectLayer/PointSelectLayer.tsx
@@ -8,7 +8,7 @@ import type { Coordinates } from '../types'
 import { MapContext } from '../Map/Map'
 import { Crosshair } from './Crosshair'
 
-export const FLY_TO_MIN_ZOOM = 13
+export const FLY_TO_MIN_ZOOM = 14
 
 const defaultIcon = icon({
   iconAnchor: [15, 40],

--- a/libs/map/tsconfig.json
+++ b/libs/map/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "types": ["../../typings/cssmodules.d.ts", "vitest/globals"]
+    "types": ["vite/client", "../../typings/cssmodules.d.ts", "vitest/globals"]
   }
 }

--- a/libs/map/vite.config.ts
+++ b/libs/map/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       exclude: ['src/index.ts'],
       include: ['src/**/*.{js,jsx,ts,tsx}'],
       thresholds: {
-        branches: 97,
+        branches: 96,
         functions: 100,
         lines: 100,
         statements: 100,

--- a/libs/map/vite.config.ts
+++ b/libs/map/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       exclude: ['src/index.ts'],
       include: ['src/**/*.{js,jsx,ts,tsx}'],
       thresholds: {
-        branches: 96,
+        branches: 97,
         functions: 100,
         lines: 100,
         statements: 100,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,6 +343,9 @@ importers:
       leaflet.markercluster:
         specifier: 1.5.3
         version: 1.5.3(leaflet@1.9.4)
+      proj4:
+        specifier: 2.21.0
+        version: 2.21.0
     devDependencies:
       '@types/geojson':
         specifier: 7946.0.16
@@ -3831,6 +3834,9 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  mgrs@1.0.0:
+    resolution: {integrity: sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==}
+
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
 
@@ -4274,6 +4280,14 @@ packages:
 
   pretty-format@3.8.0:
     resolution: {integrity: sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==}
+
+  proj4@2.21.0:
+    resolution: {integrity: sha512-33HfDftqw8kY+Cl1dcL16SJuqTSzYxmz4re7Nmhk+fs1/N1fFrAkkF579msQTR/4fLeJVSNne8/gpoCz0fk1uw==}
+    peerDependencies:
+      geotiff: '*'
+    peerDependenciesMeta:
+      geotiff:
+        optional: true
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -5198,6 +5212,9 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wkt-parser@1.5.6:
+    resolution: {integrity: sha512-cqHU3lzGt/gt2OqIORP0uVy5yeOX43WABmgFkmJsmcqH3HhQo9PiJG6ftytwGKmpQUbegeX7+pQc2BuNCRfcrw==}
 
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
@@ -8884,6 +8901,8 @@ snapshots:
 
   merge2@1.4.1: {}
 
+  mgrs@1.0.0: {}
+
   micromark-core-commonmark@2.0.3:
     dependencies:
       decode-named-character-reference: 1.3.0
@@ -9453,6 +9472,11 @@ snapshots:
       react-is: 17.0.2
 
   pretty-format@3.8.0: {}
+
+  proj4@2.21.0:
+    dependencies:
+      mgrs: 1.0.0
+      wkt-parser: 1.5.6
 
   prop-types@15.8.1:
     dependencies:
@@ -10650,6 +10674,8 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wkt-parser@1.5.6: {}
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
## What

Increase zoom level on location selection by changing to RD coordinates

## Why

Housenumbers not visible when on max zoom level
Assets too close to each other to click separately

Ticket: [SIG-7520](https://gemeente-amsterdam.atlassian.net/browse/SIG-7520)

Before opening a pull request, please ensure your branch is based on `main` and targets `main`.

- [ ] Includes AI-assisted code via GitHub Copilot

Check requirements when they are met (strikethrough when not applicable):

- [ ] Acknowledges **[team code standards](https://github.com/Amsterdam/meldingen-frontend/tree/main/docs)**
- [ ] Has **unit tests** with 100% coverage (if feasible) and all test should pass
- [ ] Has **error handling** and **loading states**
- [ ] Is **responsive and respects WCAG**
- [ ] **Documentation** has been updated
- [ ] **Required PR checks** have passed

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-7520]: https://gemeente-amsterdam.atlassian.net/browse/SIG-7520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ