### PR TITLE
Back Office adres copy for when there is only geolocation

### DIFF
--- a/apps/back-office/src/app/melding/[meldingId]/_utils/getLocationData.test.ts
+++ b/apps/back-office/src/app/melding/[meldingId]/_utils/getLocationData.test.ts
@@ -15,7 +15,7 @@ describe('getLocationData', () => {
     ])
   })
 
-  it('returns undefined when not all location data exists', () => {
+  it('returns "Locatie gekozen op de kaart" when not all location data exists', () => {
     const meldingDataWithoutPostalCode = {
       ...melding,
       postal_code: null,

--- a/apps/back-office/src/app/melding/[meldingId]/_utils/getLocationData.test.ts
+++ b/apps/back-office/src/app/melding/[meldingId]/_utils/getLocationData.test.ts
@@ -23,6 +23,12 @@ describe('getLocationData', () => {
 
     const result = getLocationData(meldingDataWithoutPostalCode, (key: string) => key)
 
-    expect(result).toEqual(undefined)
+    expect(result).toEqual([
+      {
+        description: 'detail.location.no-address',
+        key: 'address',
+        term: 'detail.location.address',
+      },
+    ])
   })
 })

--- a/apps/back-office/src/app/melding/[meldingId]/_utils/getLocationData.ts
+++ b/apps/back-office/src/app/melding/[meldingId]/_utils/getLocationData.ts
@@ -5,11 +5,9 @@ import { getFullNLAddress } from '~/app/_utils/getFullNLAddress'
 export const getLocationData = (data: MeldingOutput, t: (key: string) => string) => {
   const address = getFullNLAddress(data)
 
-  if (!address) return undefined
-
   return [
     {
-      description: address,
+      description: address ?? t('detail.location.no-address'),
       key: 'address',
       term: t('detail.location.address'),
     },

--- a/apps/back-office/translations/nl.json
+++ b/apps/back-office/translations/nl.json
@@ -63,7 +63,8 @@
       "no-data": "Niet ingevuld"
     },
     "location": {
-      "address": "Adres"
+      "address": "Adres",
+      "no-address": "Locatie gekozen op de kaart"
     },
     "assets": {
       "term": "Objecten"


### PR DESCRIPTION
## What

back-office only

- The Address Block does not get rendered when there is no valid address given.  
- This can happen when a location is chosen on the map which is far away from an actual address (e.g. on a lake or park)
- Added a new translation key

## Why

Show copy to validate a location has actually been chosen as geolocation is always present.

A later chunk of work will handle a better representation, showing a map.

Ticket: [SIG-7159](https://gemeente-amsterdam.atlassian.net/browse/SIG-7159)

Before opening a pull request, please ensure your branch is based on `main` and targets `main`.

- [ ] Includes AI-assisted code via GitHub Copilot

Check requirements when they are met (strikethrough when not applicable):

- [ ] Acknowledges **[team code standards](https://github.com/Amsterdam/meldingen-frontend/tree/main/docs)**
- [ ] Has **unit tests** with 100% coverage (if feasible) and all test should pass
- [ ] Has **error handling** and **loading states**
- [ ] Is **responsive and respects WCAG**
- [ ] **Documentation** has been updated
- [ ] **Required PR checks** have passed

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-7159]: https://gemeente-amsterdam.atlassian.net/browse/SIG-7159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ