### PR TITLE
Allow Back Office to open PDFs in new tab

### DIFF
--- a/apps/back-office/src/app/melding/[meldingId]/Detail.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/Detail.tsx
@@ -8,7 +8,9 @@ import { Column, Grid, Heading, Link, Paragraph, TabNavigation } from '@meldinge
 import type { AssetOutput, MeldingOutput } from '~/app/_api-client/proxy'
 
 import { AttachmentImage } from './_components/AttachmentImage'
+import { AttachmentPDF } from './_components/AttachmentPDF'
 import { BackLink } from './_components/BackLink'
+import { isFilePDF } from './_utils/getAttachmentsData'
 
 import styles from './Detail.module.css'
 
@@ -128,11 +130,19 @@ export const Detail = ({
             <dl className={clsx(styles.descriptionList, styles.cardWide, styles.attachmentsGrid)}>
               <dt className={styles.attachmentsTerm}>{t('attachments.title')}</dt>
               {hasAttachments ? (
-                attachments.files.map((file) => (
-                  <dd className={styles.description} key={file.fileName}>
-                    <AttachmentImage blob={file.blob} fileName={file.fileName} />
-                  </dd>
-                ))
+                attachments.files.map((file) => {
+                  const isPDF = isFilePDF(file.fileName)
+
+                  return (
+                    <dd className={styles.description} key={file.fileName}>
+                      {isPDF ? (
+                        <AttachmentPDF blob={file.blob} fileName={file.fileName} />
+                      ) : (
+                        <AttachmentImage blob={file.blob} fileName={file.fileName} />
+                      )}
+                    </dd>
+                  )
+                })
               ) : (
                 <dd className={styles.attachmentsFallBackDescription}>
                   <Paragraph>{t('attachments.no-data')}</Paragraph>

--- a/apps/back-office/src/app/melding/[meldingId]/_components/AttachmentPDF.module.css
+++ b/apps/back-office/src/app/melding/[meldingId]/_components/AttachmentPDF.module.css
@@ -1,0 +1,6 @@
+.attachmentPdf {
+  aspect-ratio: var(--ams-aspect-ratio-16-9);
+  background-color: var(--ams-color-background-body);
+  display: flex;
+  place-content: center center;
+}

--- a/apps/back-office/src/app/melding/[meldingId]/_components/AttachmentPDF.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/_components/AttachmentPDF.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+
+import { AttachmentPDF } from './AttachmentPDF'
+
+const createObjectURLMock = vi.fn().mockImplementation(() => {
+  return 'test-url'
+})
+
+global.URL.createObjectURL = createObjectURLMock
+
+describe('AttachmentPDF', () => {
+  it('renders a link when a blob is provided', async () => {
+    render(<AttachmentPDF blob={new Blob(['test-blob'], { type: 'application/pdf' })} fileName={'test.pdf'} />)
+
+    expect(createObjectURLMock).toHaveBeenCalled()
+
+    const link = screen.getByRole('link')
+
+    expect(link).toHaveAttribute('href')
+    expect(link).toHaveAttribute('target', '_blank')
+  })
+
+  it('renders an an error message when the blob is missing', async () => {
+    render(<AttachmentPDF blob={null} fileName={'test.pdf'} />)
+
+    const errorMessage = screen.getByText('test.pdf')
+
+    expect(errorMessage).toBeInTheDocument()
+  })
+})

--- a/apps/back-office/src/app/melding/[meldingId]/_components/AttachmentPDF.test.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/_components/AttachmentPDF.test.tsx
@@ -7,6 +7,7 @@ const createObjectURLMock = vi.fn().mockImplementation(() => {
 })
 
 global.URL.createObjectURL = createObjectURLMock
+global.URL.revokeObjectURL = vi.fn()
 
 describe('AttachmentPDF', () => {
   it('renders a link when a blob is provided', async () => {
@@ -26,5 +27,15 @@ describe('AttachmentPDF', () => {
     const errorMessage = screen.getByText('test.pdf')
 
     expect(errorMessage).toBeInTheDocument()
+  })
+
+  it('revokes the object URL on unmount', () => {
+    const { unmount } = render(
+      <AttachmentPDF blob={new Blob(['test-blob'], { type: 'application/pdf' })} fileName={'test.pdf'} />,
+    )
+
+    unmount()
+
+    expect(global.URL.revokeObjectURL).toHaveBeenCalledWith('test-url')
   })
 })

--- a/apps/back-office/src/app/melding/[meldingId]/_components/AttachmentPDF.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/_components/AttachmentPDF.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { DocumentsIcon } from '@amsterdam/design-system-react-icons'
+import NextLink from 'next/link'
+import { useEffect, useState } from 'react'
+
+import { Icon, Link, Paragraph } from '@meldingen/ui'
+
+import styles from './AttachmentPDF.module.css'
+
+type Props = {
+  blob: Blob | null
+  fileName: string
+}
+
+export const AttachmentPDF = ({ blob, fileName }: Props) => {
+  const [url, setUrl] = useState<string>()
+
+  useEffect(() => {
+    if (!blob) return
+    const objectUrl = URL.createObjectURL(blob)
+    setUrl(objectUrl)
+
+    return () => {
+      URL.revokeObjectURL(objectUrl)
+    }
+  }, [blob])
+
+  if (!blob || !url) return <Paragraph>{fileName}</Paragraph>
+
+  return (
+    <Link
+      className={styles.attachmentPdf}
+      href={url}
+      linkComponent={NextLink}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <Icon size="heading-1" svg={DocumentsIcon} />
+    </Link>
+  )
+}

--- a/apps/back-office/src/app/melding/[meldingId]/_components/AttachmentPDF.tsx
+++ b/apps/back-office/src/app/melding/[meldingId]/_components/AttachmentPDF.tsx
@@ -22,9 +22,11 @@ export const AttachmentPDF = ({ blob, fileName }: Props) => {
     setUrl(objectUrl)
 
     return () => {
-      URL.revokeObjectURL(objectUrl)
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl)
+      }
     }
-  }, [blob])
+  }, [])
 
   if (!blob || !url) return <Paragraph>{fileName}</Paragraph>
 
@@ -37,6 +39,7 @@ export const AttachmentPDF = ({ blob, fileName }: Props) => {
       target="_blank"
     >
       <Icon size="heading-1" svg={DocumentsIcon} />
+      <span className="ams-visually-hidden">{fileName}</span>
     </Link>
   )
 }

--- a/apps/back-office/src/app/melding/[meldingId]/_utils/getAttachmentsData.test.ts
+++ b/apps/back-office/src/app/melding/[meldingId]/_utils/getAttachmentsData.test.ts
@@ -30,11 +30,12 @@ describe('getAttachmentsData', () => {
     )
 
     server.use(
-      http.get(ENDPOINTS.GET_ATTACHMENT_BY_ID, () =>
-        HttpResponse.json(new Blob(['mock content'], { type: 'application/pdf' }), {
+      http.get(ENDPOINTS.GET_ATTACHMENT_BY_ID, ({ request }) => {
+        expect(new URL(request.url).searchParams.get('type')).toBe('original')
+        return HttpResponse.json(new Blob(['mock content'], { type: 'application/pdf' }), {
           headers: { 'content-type': 'application/pdf' },
-        }),
-      ),
+        })
+      }),
     )
 
     const result = await getAttachmentsData(mockMeldingId, (key: string) => key)

--- a/apps/back-office/src/app/melding/[meldingId]/_utils/getAttachmentsData.test.ts
+++ b/apps/back-office/src/app/melding/[meldingId]/_utils/getAttachmentsData.test.ts
@@ -7,7 +7,7 @@ import { server } from '~/mocks/node'
 const mockMeldingId = 88
 
 describe('getAttachmentsData', () => {
-  it('returns correct attachments data', async () => {
+  it('returns correct attachments data for Images', async () => {
     const result = await getAttachmentsData(mockMeldingId, (key: string) => key)
 
     expect(result).toMatchObject({
@@ -15,6 +15,38 @@ describe('getAttachmentsData', () => {
         {
           blob: expect.any(Blob),
           fileName: 'IMG_0815.jpg',
+        },
+      ],
+      key: 'attachments',
+      term: 'detail.attachments.title',
+    })
+  })
+
+  it('returns correct attachments data for PDFs', async () => {
+    server.use(
+      http.get(ENDPOINTS.GET_MELDING_BY_MELDING_ID_ATTACHMENTS, () =>
+        HttpResponse.json([{ id: 43, original_filename: 'PDF_0815.pdf' }]),
+      ),
+    )
+
+    server.use(
+      http.get(ENDPOINTS.GET_ATTACHMENT_BY_ID, () =>
+        HttpResponse.json(new Blob(['mock content'], { type: 'application/pdf' }), {
+          headers: { 'content-type': 'application/pdf' },
+        }),
+      ),
+    )
+
+    const result = await getAttachmentsData(mockMeldingId, (key: string) => key)
+
+    expect(result.files?.[0]?.blob).toBeInstanceOf(Blob)
+    expect((result.files?.[0]?.blob as Blob).type).toBe('application/pdf')
+
+    expect(result).toMatchObject({
+      files: [
+        {
+          blob: expect.any(Blob),
+          fileName: 'PDF_0815.pdf',
         },
       ],
       key: 'attachments',

--- a/apps/back-office/src/app/melding/[meldingId]/_utils/getAttachmentsData.ts
+++ b/apps/back-office/src/app/melding/[meldingId]/_utils/getAttachmentsData.ts
@@ -1,6 +1,8 @@
 import { getAttachmentById, getMeldingByMeldingIdAttachments } from '~/app/_api-client/proxy'
 import { handleApiError } from '~/app/_utils/handleApiError'
 
+export const isFilePDF = (fileName: string) => fileName.toLowerCase().endsWith('.pdf')
+
 export const getAttachmentsData = async (meldingId: number, t: (key: string) => string) => {
   const { data, error } = await getMeldingByMeldingIdAttachments({
     path: { melding_id: meldingId },
@@ -10,10 +12,9 @@ export const getAttachmentsData = async (meldingId: number, t: (key: string) => 
 
   const attachments = await Promise.all(
     data.map(async ({ id, original_filename }) => {
-      const { data, error } = await getAttachmentById({
+      const { data: attachmentBlob, error } = await getAttachmentById({
         path: { id },
-
-        query: { type: 'thumbnail' },
+        query: { type: isFilePDF(original_filename) ? 'original' : 'thumbnail' },
       })
 
       if (error) {
@@ -22,7 +23,7 @@ export const getAttachmentsData = async (meldingId: number, t: (key: string) => 
 
       // Returning blob instead of File since the File api is not available in Node.js
       return {
-        blob: data as Blob,
+        blob: attachmentBlob as Blob,
         fileName: original_filename,
       }
     }),


### PR DESCRIPTION
## What
Add functionality to open PDFs in a new tab if the Melding has it in the attachments

## Why

Allows for previewing/opening PDFs if available

Ticket: [SIG-7498](https://gemeente-amsterdam.atlassian.net/browse/SIG-7498)

- [x ] Includes AI-assisted code via GitHub Copilot

Check requirements when they are met (strikethrough when not applicable):

- [x] Acknowledges **[team code standards](https://github.com/Amsterdam/meldingen-frontend/tree/main/docs)**
- [x] Has **unit tests** with 100% coverage (if feasible) and all test should pass
- [ ] Has **error handling** and **loading states**
- [ ] Is **responsive and respects WCAG**
- [ ] **Documentation** has been updated
- [ ] **Required PR checks** have passed

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-7498]: https://gemeente-amsterdam.atlassian.net/browse/SIG-7498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ